### PR TITLE
Added an option to specify the display name for url

### DIFF
--- a/src/TrackRowLink.js
+++ b/src/TrackRowLink.js
@@ -13,6 +13,7 @@ import './TrackRowLink.scss';
  * @prop {number} trackHeight The track height.
  * @prop {array} rowInfo Array of JSON objects, one object for each row.
  * @prop {string} rowLinkAttribute The attribute used to obtain a URL from a row info JSON object.
+ * @prop {string} rowLinkNameAttribute The attribute used to display each URL from a row info JSON object.
  * @prop {string} rowLinkPosition The value of the `rowLinkPosition` option.
  */
 export default function TrackRowLink(props) {
@@ -72,7 +73,7 @@ export default function TrackRowLink(props) {
                     {info[rowLinkAttribute] ? (
                         <a 
                             href={info[rowLinkAttribute]}
-                            title={info[rowLinkNameAttribute ? rowLinkNameAttribute : rowLinkAttribute]}
+                            title={info[rowLinkAttribute]}
                             target="_blank"
                             style={{
                                 fontSize: `${fontSize}px`,

--- a/src/TrackRowLink.js
+++ b/src/TrackRowLink.js
@@ -21,7 +21,7 @@ export default function TrackRowLink(props) {
         trackX, trackY, 
         trackWidth, trackHeight, 
         rowInfo, 
-        rowLinkPosition, rowLinkAttribute
+        rowLinkPosition, rowLinkAttribute, rowLinkNameAttribute
     } = props;
 
     // Dimensions
@@ -72,7 +72,7 @@ export default function TrackRowLink(props) {
                     {info[rowLinkAttribute] ? (
                         <a 
                             href={info[rowLinkAttribute]}
-                            title={info[rowLinkAttribute]}
+                            title={info[rowLinkNameAttribute ? rowLinkNameAttribute : rowLinkAttribute]}
                             target="_blank"
                             style={{
                                 fontSize: `${fontSize}px`,
@@ -81,7 +81,7 @@ export default function TrackRowLink(props) {
                                 [textAlign]: 0
                             }}
                         >
-                            {info[rowLinkAttribute]}
+                            {info[rowLinkNameAttribute ? rowLinkNameAttribute : rowLinkAttribute]}
                         </a>
                     ) : null}
                 </div>

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -69,7 +69,7 @@ export default function TrackWrapper(props) {
                     trackHeight={trackHeight}
                     trackWidth={trackWidth}
                     rowLinkAttribute={options.rowLinkAttribute}
-                    rowLinkAttribute={options.rowLinkNameAttribute}
+                    rowLinkNameAttribute={options.rowLinkNameAttribute}
                     rowLinkPosition={options.rowLinkPosition}
                 />) : null}
             {(!combinedTrack && options.colToolsPosition !== "hidden") ? 

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -69,6 +69,7 @@ export default function TrackWrapper(props) {
                     trackHeight={trackHeight}
                     trackWidth={trackWidth}
                     rowLinkAttribute={options.rowLinkAttribute}
+                    rowLinkAttribute={options.rowLinkNameAttribute}
                     rowLinkPosition={options.rowLinkPosition}
                 />) : null}
             {(!combinedTrack && options.colToolsPosition !== "hidden") ? 

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -23,6 +23,8 @@ const demos = {
             rowInfoPosition: "left",
             rowLinkPosition: "right",
             colToolsPosition: "bottom",
+            rowLinkAttribute: "url",
+            rowLinkNameAttribute: "state",
             infoAttributes: ["r1", "r2"]
         }
     }

--- a/src/utils-options.js
+++ b/src/utils-options.js
@@ -25,6 +25,9 @@ const baseSchema = {
                 "rowLinkAttribute": {
                     "type": "string"
                 },
+                "rowLinkNameAttribute": {
+                    "type": "string"
+                },
                 "colToolsPosition": {
                     "type": "string",
                     "enum": ["hidden", "bottom", "top"]


### PR DESCRIPTION
I added an option (**rowLinkNameAttribute**) to specify an attribute that is used to display the name of each URL, instead of the URL itself. This can enable the URL to be more readable within the limited space. 

When **rowLinkNameAttribute** is not specified, the original url (i.e., **rowLinkAttribute**) will be displayed by default.

<img width="349" alt="Screen Shot 2020-02-05 at 4 44 31 PM" src="https://user-images.githubusercontent.com/9922882/73886029-ce9c3900-4836-11ea-80dc-0e77b6c4e2ae.png">
