### PR TITLE
Show genome interval coordinates and dbtoolkit link

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -1,22 +1,21 @@
 toc:
-  - name: React Components
-  - CistromeHGW
-  - name: React Components (internal)
-    children:
-    - Tooltip
-    - TrackColSelectionInfo
-    - TrackColTools
-    - TrackRowInfo
-    - TrackRowLink
-    - TrackWrapper
-  - name: functions (internal)
-    children:
-    - validateWrapperOptions
-    - processWrapperOptions
-    - getRetinaRatio
-    - setupCanvas
-    - teardownCanvas
-    - traverseViewConfig
-    - getHMTrackIdsFromViewConfig
-    - getSiblingProjectionTracksFromViewConfig
-    - updateViewConfigOnSelectGenomicInterval
+- name: React Components
+- CistromeHGW
+- name: React Components (internal)
+- Tooltip
+- TrackColSelectionInfo
+- TrackColTools
+- TrackRowInfo
+- TrackRowLink
+- TrackWrapper
+- name: functions (internal)
+- validateWrapperOptions
+- processWrapperOptions
+- getRetinaRatio
+- setupCanvas
+- teardownCanvas
+- traverseViewConfig
+- getHMTrackIdsFromViewConfig
+- getSiblingProjectionTracksFromViewConfig
+- updateViewConfigOnSelectGenomicInterval
+- resolveIntervalCoordinates

--- a/.documentation.yml
+++ b/.documentation.yml
@@ -15,5 +15,7 @@ toc:
     - getRetinaRatio
     - setupCanvas
     - teardownCanvas
-    - getTracksIdsFromViewConfig
+    - traverseViewConfig
+    - getHMTrackIdsFromViewConfig
+    - getSiblingProjectionTracks
     - updateViewConfigOnSelectGenomicInterval

--- a/.documentation.yml
+++ b/.documentation.yml
@@ -4,6 +4,7 @@ toc:
   - name: React Components (internal)
     children:
     - Tooltip
+    - TrackColSelectionInfo
     - TrackColTools
     - TrackRowInfo
     - TrackRowLink
@@ -17,5 +18,5 @@ toc:
     - teardownCanvas
     - traverseViewConfig
     - getHMTrackIdsFromViewConfig
-    - getSiblingProjectionTracks
+    - getSiblingProjectionTracksFromViewConfig
     - updateViewConfigOnSelectGenomicInterval

--- a/src/CistromeHGW.js
+++ b/src/CistromeHGW.js
@@ -61,6 +61,7 @@ export default function CistromeHGW(props) {
         const newTrackIds = getHMTrackIdsFromViewConfig(newViewConfig);
         const newSiblingTrackIds = {};
         for(let trackId of newTrackIds) {
+            // The each trackId is actually an array `[viewId, trackId]`, which is why we want trackId[1].
             newSiblingTrackIds[trackId[1]] = getSiblingProjectionTracksFromViewConfig(newViewConfig, trackId[1]);
         }
         setTrackIds(newTrackIds);
@@ -122,8 +123,6 @@ export default function CistromeHGW(props) {
     }, [viewConfig]);
 
     
-    
-
     console.log("CistromeHGW.render");
     return (
         <div className="cistrome-hgw">

--- a/src/CistromeHGW.js
+++ b/src/CistromeHGW.js
@@ -51,19 +51,20 @@ export default function CistromeHGW(props) {
     const hgRef = useRef();
 
     const [options, setOptions] = useState({});
+
+    // Array of horizontal-multivec track IDs.
     const [trackIds, setTrackIds] = useState([]);
+    // Mapping of horizontal-multivec track IDs to arrays of viewport-projection sibling track IDs.
     const [siblingTrackIds, setSiblingTrackIds] = useState({});
 
     const onViewConfig = useCallback((newViewConfig) => {
         const newTrackIds = getHMTrackIdsFromViewConfig(newViewConfig);
-        
         const newSiblingTrackIds = {};
         for(let trackId of newTrackIds) {
             newSiblingTrackIds[trackId[1]] = getSiblingProjectionTracksFromViewConfig(newViewConfig, trackId[1]);
         }
         setTrackIds(newTrackIds);
         setSiblingTrackIds(newSiblingTrackIds);
-        
     }, []);
 
     const getTrackObject = useCallback((viewId, trackId) => {
@@ -137,7 +138,9 @@ export default function CistromeHGW(props) {
                     onSelectGenomicInterval={() => {
                         const currViewConfig = hgRef.current.api.getViewConfig();
                         const newViewConfig = updateViewConfigOnSelectGenomicInterval(currViewConfig, viewId, trackId);
-                        hgRef.current.api.setViewConfig(newViewConfig);
+                        hgRef.current.api.setViewConfig(newViewConfig).then(() => {
+                            onViewConfig(newViewConfig);
+                        });
                     }}
                 />
             ))}

--- a/src/CistromeHGW.scss
+++ b/src/CistromeHGW.scss
@@ -6,3 +6,6 @@
     text-align: left;
 }
 
+.cistrome-hgw-child {
+    position: absolute;
+}

--- a/src/TrackColSelectionInfo.js
+++ b/src/TrackColSelectionInfo.js
@@ -6,7 +6,9 @@ import { CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE } from './constants.js';
 
 import './TrackColSelectionInfo.scss';
 
+
 function makeDbToolkitURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
+    // Generate a URL for the cistrome DB toolkit site.
     if(chrStartName !== chrEndName) {
         // Bail out, interval spans across more than one chromosome.
         return null;
@@ -22,11 +24,8 @@ const numberFormatter = d3_format(",");
 
 /**
  * Component for rendering information about a particular genomic interval selection.
- * @prop {number} trackX The track horizontal offset.
- * @prop {number} trackY The track vertical offset.
- * @prop {number} trackWidth The track width.
- * @prop {number} trackHeight The track height.
- * @prop {string} colToolsPosition The value of the `colToolsPosition` option.
+ * @prop {object} projectionTrack A `viewport-projection-horizontal` track object.
+ * @prop {(string|null)} trackAssembly The genome assembly/coordSystem value obtained from the associated `horizontal-multivec` track.
  */
 export default function TrackColSelectionInfo(props) {
 

--- a/src/TrackColSelectionInfo.js
+++ b/src/TrackColSelectionInfo.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+
+import { resolveIntervalCoordinates } from './utils-genome.js';
+
+import './TrackColSelectionInfo.scss';
+
+/**
+ * Component for rendering information about a particular genomic interval selection.
+ * @prop {number} trackX The track horizontal offset.
+ * @prop {number} trackY The track vertical offset.
+ * @prop {number} trackWidth The track width.
+ * @prop {number} trackHeight The track height.
+ * @prop {string} colToolsPosition The value of the `colToolsPosition` option.
+ */
+export default function TrackColSelectionInfo(props) {
+
+    const {
+        projectionTrack
+    } = props;
+
+    const [chrStartName, setChrStartName] = useState(null);
+    const [chrStartPos, setChrStartPos] = useState(null);
+    const [chrEndName, setChrEndName] = useState(null);
+    const [chrEndPos, setChrEndPos] = useState(null);
+
+    console.log(projectionTrack)
+
+    useEffect(() => {
+        const absDomain = projectionTrack.viewportXDomain;
+        resolveIntervalCoordinates("hg38", absDomain[0], absDomain[1])
+        .then(result => {
+            setChrStartName(result[0][0]);
+            setChrStartPos(result[0][1]);
+            setChrEndName(result[1][0]);
+            setChrEndPos(result[1][1]);
+        });
+    });
+
+    return (
+        <div>
+            {chrStartName}:{chrStartPos} - {chrEndName}:{chrEndPos}
+        </div>
+    );
+};

--- a/src/TrackColSelectionInfo.js
+++ b/src/TrackColSelectionInfo.js
@@ -4,6 +4,24 @@ import { resolveIntervalCoordinates } from './utils-genome.js';
 
 import './TrackColSelectionInfo.scss';
 
+const ASSEMBLY = "hg38"; // TODO: obtain this from the tilesetInfo for the horizontal-multivec track.
+
+function makeDbToolkitURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
+    if(!assembly || !chrStartName || !chrStartPos || !chrEndName || !chrEndPos) {
+        // We need all of these values to be able to generate the URL.
+        return null;
+    }
+    if(chrStartName !== chrEndName) {
+        // Bail out, interval spans across more than one chromosome.
+        return null;
+    }
+    if(chrEndPos - chrStartPos > 2000000) {
+        // Bail out, interval spans across more than 2 Mb, the maximum for dbtoolkit's interval search.
+        return null;
+    }
+    return `http://dbtoolkit.cistrome.org/?specie=${assembly}&factor=tf&interval=${chrStartName}%3A${chrStartPos}-${chrEndPos}`;
+}
+
 /**
  * Component for rendering information about a particular genomic interval selection.
  * @prop {number} trackX The track horizontal offset.
@@ -23,22 +41,39 @@ export default function TrackColSelectionInfo(props) {
     const [chrEndName, setChrEndName] = useState(null);
     const [chrEndPos, setChrEndPos] = useState(null);
 
-    console.log(projectionTrack)
-
     useEffect(() => {
+        let didUnmount = false;
         const absDomain = projectionTrack.viewportXDomain;
-        resolveIntervalCoordinates("hg38", absDomain[0], absDomain[1])
+        resolveIntervalCoordinates(ASSEMBLY, absDomain[0], absDomain[1])
         .then(result => {
-            setChrStartName(result[0][0]);
-            setChrStartPos(result[0][1]);
-            setChrEndName(result[1][0]);
-            setChrEndPos(result[1][1]);
+            if(!didUnmount) {
+                // Only update state if the component has not yet unmounted.
+                // See https://github.com/facebook/react/issues/14369#issuecomment-468267798
+                setChrStartName(result[0][0]);
+                setChrStartPos(result[0][1]);
+                setChrEndName(result[1][0]);
+                setChrEndPos(result[1][1]);
+            }
         });
+
+        return (() => { didUnmount = true; });
     });
+
+    const dbToolkitURL = makeDbToolkitURL(ASSEMBLY, chrStartName, chrStartPos, chrEndName, chrEndPos);
 
     return (
         <div>
-            {chrStartName}:{chrStartPos} - {chrEndName}:{chrEndPos}
+            <div>
+                {chrStartName}:{chrStartPos} - {chrEndName}:{chrEndPos}
+            </div>
+            {dbToolkitURL ? (
+                <a 
+                    href={dbToolkitURL}
+                    target="_blank"
+                >
+                    View on DB Toolkit
+                </a>
+            ) : null}
         </div>
     );
 };

--- a/src/TrackColSelectionInfo.scss
+++ b/src/TrackColSelectionInfo.scss
@@ -1,0 +1,3 @@
+.col-selection-info-disabled {
+    color: silver;
+}

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -36,28 +36,28 @@ export default function TrackColTools(props) {
     
     return (
         <div
+            className="cistrome-hgw-child"
             style={{
-                position: 'absolute',
                 top: `${top}px`,
                 left: `${left}px`, 
                 width: `${width}px`,
                 height: `${height}px`
             }}
         >
-            {!combinedTrack ? (
-                <div className="col-tools">
+            <div className="col-tools">
+                {!combinedTrack ? (
                     <button onClick={onSelectGenomicInterval}>Select genomic interval</button>
-                </div>
-            ) : (
-                <div className="col-tools-selection-info">
-                    {siblingTracks.map((siblingTrack, i) => (
-                        <TrackColSelectionInfo
-                            key={i}
-                            projectionTrack={siblingTrack}
-                        />
-                    ))}
-                </div>
-            )}
+                ) : (
+                    <div className="col-tools-selection-info">
+                        {siblingTracks.map((siblingTrack, i) => (
+                            <TrackColSelectionInfo
+                                key={i}
+                                projectionTrack={siblingTrack}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
         </div>
     );
 };

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -10,7 +10,11 @@ import './TrackColTools.scss';
  * @prop {number} trackY The track vertical offset.
  * @prop {number} trackWidth The track width.
  * @prop {number} trackHeight The track height.
+ * @prop {(object|null)} combinedTrack The `combined` track, parent of the `horizontal-multivec` track.
+ * @prop {object[]} siblingTracks An array of `viewport-projection-horizontal` track objects, which
+ *                                are siblings of `multivecTrack` (children of the same `combined` track).
  * @prop {string} colToolsPosition The value of the `colToolsPosition` option.
+ * @prop {function} onSelectGenomicInterval The function to call upon selection of a genomic interval.
  */
 export default function TrackColTools(props) {
 

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import TrackColSelectionInfo from './TrackColSelectionInfo.js';
+
 import './TrackColTools.scss';
 
 /**
@@ -15,6 +17,8 @@ export default function TrackColTools(props) {
     const {
         trackX, trackY, 
         trackWidth, trackHeight,
+        combinedTrack,
+        siblingTracks,
         colToolsPosition,
         onSelectGenomicInterval
     } = props;
@@ -29,7 +33,7 @@ export default function TrackColTools(props) {
     } else if(colToolsPosition === "bottom") {
         top = trackY + trackHeight;
     }
-
+    
     return (
         <div
             style={{
@@ -40,9 +44,20 @@ export default function TrackColTools(props) {
                 height: `${height}px`
             }}
         >
-            <div className="col-tools">
-                <button onClick={onSelectGenomicInterval}>Select genomic interval</button>
-            </div>
+            {!combinedTrack ? (
+                <div className="col-tools">
+                    <button onClick={onSelectGenomicInterval}>Select genomic interval</button>
+                </div>
+            ) : (
+                <div className="col-tools-selection-info">
+                    {siblingTracks.map((siblingTrack, i) => (
+                        <TrackColSelectionInfo
+                            key={i}
+                            projectionTrack={siblingTrack}
+                        />
+                    ))}
+                </div>
+            )}
         </div>
     );
 };

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -17,11 +17,17 @@ export default function TrackColTools(props) {
     const {
         trackX, trackY, 
         trackWidth, trackHeight,
+        trackAssembly,
         combinedTrack,
         siblingTracks,
         colToolsPosition,
         onSelectGenomicInterval
     } = props;
+
+    if(!trackAssembly) {
+        console.warn("trackAssembly is null");
+        return null;
+    }
 
     const left = trackX;
     const width = trackWidth;
@@ -52,6 +58,7 @@ export default function TrackColTools(props) {
                         {siblingTracks.map((siblingTrack, i) => (
                             <TrackColSelectionInfo
                                 key={i}
+                                trackAssembly={trackAssembly}
                                 projectionTrack={siblingTrack}
                             />
                         ))}

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -31,7 +31,7 @@ export default function TrackColTools(props) {
 
     const left = trackX;
     const width = trackWidth;
-    const height = 30;
+    const height = 40;
 
     let top;
     if(colToolsPosition === "top") {

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -135,13 +135,21 @@ export default function TrackRowInfo(props) {
     });
 
     return (
-        <div>
+        <div 
+            className="cistrome-hgw-child"
+            style={{
+                top: `${top}px`,
+                left: `${left}px`, 
+                width: `${width}px`,
+                height: `${height}px`,
+            }}
+        >
             <canvas
                 ref={canvasRef}
                 style={{
-                    position: 'absolute',
-                    top: `${top}px`,
-                    left: `${left}px`, 
+                    position: 'relative',
+                    top: 0,
+                    left: 0, 
                     width: `${width}px`,
                     height: `${height}px`,
                 }}

--- a/src/TrackRowLink.js
+++ b/src/TrackRowLink.js
@@ -52,8 +52,8 @@ export default function TrackRowLink(props) {
 
     return (
         <div
+            className="cistrome-hgw-child"
             style={{
-                position: 'absolute',
                 top: `${top}px`,
                 left: `${left}px`, 
                 width: `${width}px`,

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -12,8 +12,10 @@ import fakedata from './demo/fakedata/index.js';
  * Wrapper component associated with a particular HiGlass track.
  * @prop {object} options Options associated with the track. Contains values for all possible options.
  * @prop {object} multivecTrack A `horizontal-multivec` track object returned by `hgc.api.getTrackObject()`.
- * @prop {object} combinedTrack A `combined` track object returned by `hgc.api.getTrackObject()`. 
+ * @prop {(object|null)} combinedTrack A `combined` track object returned by `hgc.api.getTrackObject()`. 
  *                              If not null, it is the parent track of the `multivecTrack`.
+ * @prop {object[]} siblingTracks An array of `viewport-projection-horizontal` track objects, which
+ *                                are siblings of `multivecTrack` (children of the same `combined` track).
  * @prop {function} onSelectGenomicInterval The function to call upon selection of a genomic interval. 
  *                                          Passed down to the `TrackColTools` component.
  */

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -22,6 +22,7 @@ export default function TrackWrapper(props) {
         options, 
         multivecTrack,
         combinedTrack,
+        siblingTracks,
         onSelectGenomicInterval
     } = props;
 
@@ -72,12 +73,14 @@ export default function TrackWrapper(props) {
                     rowLinkAttribute={options.rowLinkAttribute}
                     rowLinkPosition={options.rowLinkPosition}
                 />) : null}
-            {(!combinedTrack && options.colToolsPosition !== "hidden") ? 
+            {options.colToolsPosition !== "hidden" ? 
                 (<TrackColTools
                     trackX={trackX}
                     trackY={trackY}
                     trackHeight={trackHeight}
                     trackWidth={trackWidth}
+                    combinedTrack={combinedTrack}
+                    siblingTracks={siblingTracks}
                     colToolsPosition={options.colToolsPosition}
                     onSelectGenomicInterval={onSelectGenomicInterval}
                 />) : null}

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -35,8 +35,12 @@ export default function TrackWrapper(props) {
     const trackY = multivecTrack.position[1];
     const trackWidth = multivecTrack.dimensions[0];
     const trackHeight = multivecTrack.dimensions[1];
+
+    // Attempt to obtain metadata values from the `tilesetInfo` field of the track.
     let rowInfo = [];
+    let trackAssembly = null;
     try {
+        trackAssembly = multivecTrack.tilesetInfo.coordSystem;
         // TODO: uncomment the below line to use the real metadata coming from the HiGlass Server.
         //       see https://github.com/hms-dbmi/cistrome-higlass-wrapper/issues/26
         // rowInfo = multivecTrack.tilesetInfo.row_infos.map(JSON.parse);
@@ -46,7 +50,7 @@ export default function TrackWrapper(props) {
         const numRows = multivecTrack.tilesetInfo.shape[1];
         rowInfo = fakedata[multivecTrack.id].tilesetInfo.rowInfo.slice(0, numRows);
     } catch(e) {
-        console.log(e)
+        console.log(e);
     }
 
     console.log("TrackWrapper.render");
@@ -78,6 +82,7 @@ export default function TrackWrapper(props) {
                     trackY={trackY}
                     trackHeight={trackHeight}
                     trackWidth={trackWidth}
+                    trackAssembly={trackAssembly}
                     combinedTrack={combinedTrack}
                     siblingTracks={siblingTracks}
                     colToolsPosition={options.colToolsPosition}

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,3 +23,5 @@ export const POSITION = Object.freeze({
     RIGHT: "right",
     TOP: "top"
 });
+
+export const CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE = 2000000;

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,3 +13,13 @@ export const TRACK_TYPE = Object.freeze({
 export const EVENT = Object.freeze({
     TOOLTIP: "tooltip"
 });
+
+/*
+ * Child component positions
+ */
+export const POSITION = Object.freeze({
+    BOTTOM: "bottom",
+    LEFT: "left",
+    RIGHT: "right",
+    TOP: "top"
+});

--- a/src/utils-genome.js
+++ b/src/utils-genome.js
@@ -1,0 +1,39 @@
+import { ChromosomeInfo } from 'higlass';
+
+const CHROM_INFO_SERVER = "https://higlass.io/api/v1";
+const CHROM_SIZES_URL = `${CHROM_INFO_SERVER}/chrom-sizes/`;
+const AVAILABLE_CHROM_SIZES_URL = `${CHROM_INFO_SERVER}/available-chrom-sizes/`;
+
+/**
+ * Convert absolute genomic positions to relative genomic positions.
+ * See https://docs.higlass.io/javascript_api.html#obtaining-ordered-chromosome-info.
+ * @param {string} coordSystem The genome assembly, corresponds to the value of `coordSystem`.
+ * @param {number} absStart The genome absolute position of the start of the interval.
+ * @param {number} absEnd The genome absolute position of the end of the interval.
+ * @returns {promise} A promise that resolves with `[[chrStartName, chrStartPos], [chrEndName, chrEndPos]]`.
+ */
+export function resolveIntervalCoordinates(coordSystem, absStart, absEnd) {
+    return new Promise((resolve, reject) => {
+        fetch(AVAILABLE_CHROM_SIZES_URL, {
+            credentials: 'same-origin',
+            cache: 'force-cache'
+        })
+        .then(response => {
+            return response.json();
+        })
+        .then(data => {
+            const coordSystemInfo = data.results.find(d => d.coordSystem === coordSystem);
+            ChromosomeInfo(
+                `${CHROM_SIZES_URL}?id=${coordSystemInfo.uuid}`,
+                (chromInfo) => {
+                    const chrStart = chromInfo.absToChr(absStart);
+                    const chrEnd = chromInfo.absToChr(absEnd);
+                    resolve([chrStart, chrEnd]);
+                }
+            );
+        })
+        .catch(() => {
+            reject();
+        });
+    });
+};

--- a/src/utils-genome.js
+++ b/src/utils-genome.js
@@ -10,7 +10,7 @@ const AVAILABLE_CHROM_SIZES_URL = `${CHROM_INFO_SERVER}/available-chrom-sizes/`;
  * @param {string} coordSystem The genome assembly, corresponds to the value of `coordSystem`.
  * @param {number} absStart The genome absolute position of the start of the interval.
  * @param {number} absEnd The genome absolute position of the end of the interval.
- * @returns {promise} A promise that resolves with `[[chrStartName, chrStartPos], [chrEndName, chrEndPos]]`.
+ * @returns {promise<array>} A promise that resolves with `[[chrStartName, chrStartPos], [chrEndName, chrEndPos]]`.
  */
 export function resolveIntervalCoordinates(coordSystem, absStart, absEnd) {
     return new Promise((resolve, reject) => {

--- a/src/utils-viewconf.spec.js
+++ b/src/utils-viewconf.spec.js
@@ -1,20 +1,25 @@
 /* eslint-env node */
 
-import { getTracksIdsFromViewConfig, updateViewConfigOnSelectGenomicInterval } from './utils-viewconf.js';
+import { 
+    getHMTrackIdsFromViewConfig,
+    getSiblingProjectionTracksFromViewConfig,
+    updateViewConfigOnSelectGenomicInterval
+} from './utils-viewconf.js';
 
 import hgDemoViewConfig1 from './viewconfigs/horizontal-multivec-1.json';
 import hgDemoViewConfig2 from './viewconfigs/horizontal-multivec-2.json';
+import hgDemoViewConfig3 from './viewconfigs/horizontal-multivec-3.json';
 
 describe('Utilities for processing higlass view config objects', () => {
     it('Should find all horizontal-multivec track IDs', () => {
-        const trackIds1 = getTracksIdsFromViewConfig(hgDemoViewConfig1);
+        const trackIds1 = getHMTrackIdsFromViewConfig(hgDemoViewConfig1);
         expect(trackIds1.length).toEqual(1);
         expect(trackIds1[0].length).toEqual(3);
         expect(trackIds1[0][0]).toEqual("cistrome-view-1");
         expect(trackIds1[0][1]).toEqual("cistrome-track-1");
         expect(trackIds1[0][2]).toBeNull();
 
-        const trackIds2 = getTracksIdsFromViewConfig(hgDemoViewConfig2);
+        const trackIds2 = getHMTrackIdsFromViewConfig(hgDemoViewConfig2);
         expect(trackIds2.length).toEqual(1);
         expect(trackIds2[0].length).toEqual(3);
         expect(trackIds2[0][0]).toEqual("cistrome-view-2");
@@ -34,6 +39,15 @@ describe('Utilities for processing higlass view config objects', () => {
         expect(newViewConfig.views[0].tracks.center[0].contents[0].uid).toEqual("cistrome-track-1");
         expect(newViewConfig.views[0].tracks.center[0].contents[1].type).toEqual("viewport-projection-horizontal");
         expect(newViewConfig.views[0].tracks.center[0].contents[1].uid).toEqual("cistrome-track-1-projection");
+    });
+
+    it('Should find all viewport-projection-horizontal track siblings of a particular horizontal-multivec track', () => {
+        const siblingTrackIds = getSiblingProjectionTracksFromViewConfig(hgDemoViewConfig3, "cistrome-track-1");
+        expect(siblingTrackIds.length).toEqual(1);
+        expect(siblingTrackIds[0]).toEqual(["cistrome-view-1-with-projection", "cistrome-track-1-projection", "cistrome-track-1-combined"]);
+
+        const siblingTrackIdsEmpty = getSiblingProjectionTracksFromViewConfig(hgDemoViewConfig3, "some-unknown-track");
+        expect(siblingTrackIdsEmpty.length).toEqual(0);
     });
 
 });

--- a/src/viewconfigs/horizontal-multivec-1.json
+++ b/src/viewconfigs/horizontal-multivec-1.json
@@ -15,13 +15,6 @@
           2671196920.8697634,
           2671320441.9350777
         ],
-        "genomePositionSearchBox": {
-            "autocompleteServer": "//higlass.io/api/v1",
-            "autocompleteId": "OHJakQICQD6gTD7skx4EWA",
-            "chromInfoServer": "//higlass.io/api/v1",
-            "chromInfoId": "hg19",
-            "visible": true
-        },
         "tracks": {
           "top": [
             {

--- a/src/viewconfigs/horizontal-multivec-3.json
+++ b/src/viewconfigs/horizontal-multivec-3.json
@@ -8,19 +8,19 @@
     "views": [
       {
         "initialXDomain": [
-          226426442.00375226,
-          226667818.0304663
+          223802565.63927206,
+          230164009.71560466
         ],
         "initialYDomain": [
-          2671196920.8697634,
-          2671320441.9350777
+          2669832509.996859,
+          2672092117.9606247
         ],
         "genomePositionSearchBox": {
-            "autocompleteServer": "//higlass.io/api/v1",
-            "autocompleteId": "OHJakQICQD6gTD7skx4EWA",
-            "chromInfoServer": "//higlass.io/api/v1",
-            "chromInfoId": "hg19",
-            "visible": true
+          "autocompleteServer": "//higlass.io/api/v1",
+          "autocompleteId": "OHJakQICQD6gTD7skx4EWA",
+          "chromInfoServer": "//higlass.io/api/v1",
+          "chromInfoId": "hg19",
+          "visible": true
         },
         "tracks": {
           "top": [
@@ -91,7 +91,8 @@
                 "labelTopMargin": 0,
                 "labelBottomMargin": 0,
                 "labelShowResolution": false,
-                "axisLabelFormatting": "scientific"
+                "axisLabelFormatting": "scientific",
+                "labelShowAssembly": true
               },
               "width": 568,
               "height": 42,
@@ -175,46 +176,71 @@
           "left": [],
           "center": [
             {
-              "type": "horizontal-multivec",
-              "uid": "cistrome-track-1",
-              "tilesetUid": "UvVPeLHuRDiYA3qwFlm7xQ",
-              "server": "https://resgen.io/api/v1",
-              "options": {
-                "labelPosition": "hidden",
-                "labelColor": "black",
-                "labelTextOpacity": 0.4,
-                "valueScaling": "linear",
-                "trackBorderWidth": 0,
-                "trackBorderColor": "black",
-                "heatmapValueScaling": "log",
-                "name": "my_file_genome_wide.multires.mv5",
-                "labelLeftMargin": 0,
-                "labelRightMargin": 0,
-                "labelTopMargin": 0,
-                "labelBottomMargin": 0,
-                "labelShowResolution": true,
-                "minHeight": 100,
-                "colorbarPosition": "bottomLeft"
-              },
-              "width": 1607,
+              "type": "combined",
+              "uid": "cistrome-track-1-combined",
               "height": 482,
-              "resolutions": [
-                16384000,
-                8192000,
-                4096000,
-                2048000,
-                1024000,
-                512000,
-                256000,
-                128000,
-                64000,
-                32000,
-                16000,
-                8000,
-                4000,
-                2000,
-                1000
-              ]
+              "width": 1607,
+              "contents": [
+                {
+                  "type": "horizontal-multivec",
+                  "uid": "cistrome-track-1",
+                  "tilesetUid": "UvVPeLHuRDiYA3qwFlm7xQ",
+                  "server": "https://resgen.io/api/v1",
+                  "options": {
+                    "labelPosition": "hidden",
+                    "labelColor": "black",
+                    "labelTextOpacity": 0.4,
+                    "valueScaling": "linear",
+                    "trackBorderWidth": 0,
+                    "trackBorderColor": "black",
+                    "heatmapValueScaling": "log",
+                    "name": "my_file_genome_wide.multires.mv5",
+                    "labelLeftMargin": 0,
+                    "labelRightMargin": 0,
+                    "labelTopMargin": 0,
+                    "labelBottomMargin": 0,
+                    "labelShowResolution": true,
+                    "minHeight": 100,
+                    "colorbarPosition": "bottomLeft",
+                    "labelShowAssembly": true,
+                    "colorbarBackgroundColor": "#ffffff",
+                    "scaleStartPercent": "0.00000",
+                    "scaleEndPercent": "1.00000"
+                  },
+                  "width": 1607,
+                  "height": 482,
+                  "resolutions": [
+                    16384000,
+                    8192000,
+                    4096000,
+                    2048000,
+                    1024000,
+                    512000,
+                    256000,
+                    128000,
+                    64000,
+                    32000,
+                    16000,
+                    8000,
+                    4000,
+                    2000,
+                    1000
+                  ]
+                },
+                {
+                  "uid": "cistrome-track-1-projection",
+                  "type": "viewport-projection-horizontal",
+                  "fromViewUid": "cistrome-view-1",
+                  "options": {
+                    "projectionFillColor": "#777",
+                    "projectionStrokeColor": "#777",
+                    "projectionFillOpacity": 0.3,
+                    "projectionStrokeOpacity": 0.7,
+                    "strokeWidth": 1
+                  }
+                }
+              ],
+              "options": {}
             }
           ],
           "bottom": [],
@@ -224,13 +250,13 @@
         },
         "layout": {
           "w": 12,
-          "h": 10,
+          "h": 71,
           "x": 0,
           "y": 0,
           "moved": false,
           "static": false
         },
-        "uid": "cistrome-view-1"
+        "uid": "cistrome-view-1-with-projection"
       }
     ],
     "zoomLocks": {
@@ -245,4 +271,4 @@
       "locksByViewUid": {},
       "locksDict": {}
     }
-}
+  }


### PR DESCRIPTION
This adds the `TrackColSelectionInfo` component, which appears if a genomic selection has been made, and shows the genomic coordinates. If the interval is less than 2 Mb, a link to search for the interval on http://dbtoolkit.cistrome.org/ appears. Fixes #11.

Because higlass uses absolute genome coordinates, it seems that I need to fetch the chromosome sizes for the current genome assembly before doing the conversion. I will also try to check with the higlass developer slack and ask whether making this request is necessary or if there is some way to obtain this information directly from the higlass component if it already has the chromosome sizes. https://github.com/hms-dbmi/cistrome-higlass-wrapper/compare/keller-mark/genome-interval-info?expand=1#diff-696d2da7332664c34286d27e050ab540R15

For now, the text that displays the interval is just centered, but I will make a new "enhancement" issue about positioning the start/end coordinates relative to the genome. Also, we may want to show the coordinates in an svg rather than in html so they can be contained in an svg export.