### PR TITLE
More comments in the two.js file

### DIFF
--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -148,7 +148,7 @@ export default function TrackRowInfo(props) {
                 height: `${height}px`,
             }}
         >
-            <canvas
+            <svg
                 ref={canvasRef}
                 style={{
                     position: 'relative',

--- a/src/VerticalBarTrack.js
+++ b/src/VerticalBarTrack.js
@@ -53,21 +53,21 @@ export function verticalBarTrack(props) {
     const title = two.makeText(titleLeft, top, rowHeight, colWidth, titleText);
     title.fill = "#9A9A9A";
     title.fontsize = titleFontSize;
-    title.align = isLeft ? "right" : "left";
+    title.align = isLeft ? "end" : "start";
     title.baseline = "top";
     title.rotation = titleRotate;
 
     // Render visual components for each row (i.e., bars and texts)
     const barLeft = left + (isLeft ? xMargin : 0);
     const labelLeft = left + (isLeft ? xMargin - xGap : colWidth + xGap);
-    const labelAlign = isLeft ? "right" : "left";
+    const labelAlign = isLeft ? "end" : "start";
 
     rowInfo.forEach((d, i) => {
         const color = attribute.type === "nominal" ?
             colorScale(d[attribute.name]) : 
             d3.interpolateViridis(colorScale(d[attribute.name]));
 
-        const rect = two.makeRect(barLeft + colWidth/2, yScale(i) + rowHeight/2, colWidth, rowHeight);
+        const rect = two.makeRect(barLeft, yScale(i), colWidth, rowHeight);
         rect.fill = color;
 
         // Render text labels when the space is enough


### PR DESCRIPTION
This adds jsdoc comments, but also updates the (x,y) parameters for the `two.makeRect` function so they no longer need to be for the center of the rect. And I changed the `text.align` options to "start", "middle", "end" to be more consistent with the canvas and SVG APIs.