### PR TITLE
Implemented horizontal bars for quantitative values

### DIFF
--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -41,8 +41,8 @@ export default function TrackRowInfo(props) {
     // Dimensions
     const isLeft = rowInfoPosition === "left";
     const top = trackY;
-    const barWidth = 10;
-    const textWidth = 60;
+    const barWidth = 20;
+    const textWidth = 50;
     const margin = 5;
     const width = (barWidth + textWidth) * infoAttributes.length;
     const height = trackHeight;

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -41,10 +41,9 @@ export default function TrackRowInfo(props) {
     // Dimensions
     const isLeft = rowInfoPosition === "left";
     const top = trackY;
-    const barWidth = 20;
-    const textWidth = 50;
+    const unitWidth = 70;
+    const width = unitWidth * infoAttributes.length;
     const margin = 5;
-    const width = (barWidth + textWidth) * infoAttributes.length;
     const height = trackHeight;
     const left = isLeft ? trackX - margin - width : trackX + trackWidth + margin;
 
@@ -55,19 +54,12 @@ export default function TrackRowInfo(props) {
     let xDomain = [], xRange = [];
     for(let i = 0; i < infoAttributes.length; i++) {
         const attribute = isLeft ? infoAttributes[infoAttributes.length - i - 1] : infoAttributes[i];
-        let currentLeft = (barWidth + textWidth) * i;
+        let currentLeft = unitWidth * i;
 
         // Domain and range for mouse event
-        if(isLeft) {
-            xDomain.push(currentLeft + textWidth, currentLeft + textWidth + barWidth);
-            xRange.push("m", attribute.name);
-        } else {
-            xDomain.push(currentLeft, currentLeft + barWidth);
-            xRange.push("m", attribute.name);
-        }
+        xDomain.push(currentLeft + unitWidth);
+        xRange.push(attribute.name);
     }
-    xDomain.push(width);
-    xRange.push("m");
     
     // Scales
     const xScale = d3.scaleThreshold()
@@ -86,11 +78,11 @@ export default function TrackRowInfo(props) {
       
         for(let i = 0; i < infoAttributes.length; i++) {
             const attribute = isLeft ? infoAttributes[infoAttributes.length - i - 1] : infoAttributes[i];
-            let currentLeft = (barWidth + textWidth) * i;
+            let currentLeft = unitWidth * i;
 
             verticalBarTrack({
                 two, 
-                left: currentLeft, top: 0, width: barWidth + textWidth, height: height,
+                left: currentLeft, top: 0, width: unitWidth, height: height,
                 rowInfo,
                 attribute,
                 isLeft

--- a/src/VerticalBarTrack.js
+++ b/src/VerticalBarTrack.js
@@ -52,25 +52,8 @@ export function verticalBarTrack(props) {
     rowInfo.forEach((d, i) => {
         const barWidth = isNominal ? barAreaWidth : xScale(d[attribute.name]);
         
-        let barLeft = left;
-        if(isLeft) {
-            if(isNominal) {
-                barLeft += width - barAreaWidth;
-            } else {
-                barLeft += width - barWidth;
-            }
-        } else { }
-
-        let textLeft = left;
-        if(isLeft) {
-            if(isNominal) {
-                textLeft += textAreaWidth - margin;
-            } else {
-                textLeft += width - barWidth - margin;
-            }
-        } else {
-            textLeft += barWidth + margin;
-        }
+        const barLeft = left + (isLeft ? width - barWidth : 0);
+        const textLeft = left + (isLeft ? width - barWidth - margin : barWidth + margin);
         const color = attribute.type === "nominal" ?
             colorScale(d[attribute.name]) : 
             d3.interpolateViridis(colorScale(d[attribute.name]));

--- a/src/VerticalBarTrack.js
+++ b/src/VerticalBarTrack.js
@@ -23,20 +23,20 @@ export function verticalBarTrack(props) {
 
     // Layouts and styles
     const isNominal = attribute.type === "nominal";
-    const barWidth = isNominal ? 20 : 50;
-    const textWidth = isNominal ? 50 : 20;
+    const barAreaWidth = isNominal ? 20 : 50;
+    const textAreaWidth = isNominal ? 50 : 20;
     const margin = 5;
     const titleFontSize = 12;
     const fontSize = 10;
     
     // Scales
-    const valueExtent = [0, d3.extent(rowInfo.map(d => d[attribute.name]))[1]];   // zero baseline
+    const valueExtent = [0, d3.extent(rowInfo.map(d => d[attribute.name]))[1]];   // Zero baseline
     const yScale = d3.scaleBand()
         .domain(range(rowInfo.length))
         .range([0, height]);
     const xScale = d3.scaleLinear()
         .domain(valueExtent)
-        .range([0, barWidth])
+        .range([0, barAreaWidth])
     const colorScale = attribute.type === "nominal" ? 
         d3.scaleOrdinal()
             .domain(Array.from(new Set(rowInfo.map(d => d[attribute.name]))))
@@ -46,23 +46,41 @@ export function verticalBarTrack(props) {
             .range([0, 1]);
     const rowHeight = yScale.bandwidth();
 
-    // Render visual components for each row (i.e., bars and texts)
-    const barLeft = left + (isLeft ? textWidth : 0);
+    // Render visual components for each row (i.e., bars and texts).
     const textAlign = isLeft ? "end" : "start";
 
     rowInfo.forEach((d, i) => {
-        const barLength = isNominal ? barWidth : xScale(d[attribute.name]);
-        const textLeft = left + (isLeft ? textWidth - margin : barLength + margin);
+        const barWidth = isNominal ? barAreaWidth : xScale(d[attribute.name]);
+        
+        let barLeft = left;
+        if(isLeft) {
+            if(isNominal) {
+                barLeft += width - barAreaWidth;
+            } else {
+                barLeft += width - barWidth;
+            }
+        } else { }
+
+        let textLeft = left;
+        if(isLeft) {
+            if(isNominal) {
+                textLeft += textAreaWidth - margin;
+            } else {
+                textLeft += width - barWidth - margin;
+            }
+        } else {
+            textLeft += barWidth + margin;
+        }
         const color = attribute.type === "nominal" ?
             colorScale(d[attribute.name]) : 
             d3.interpolateViridis(colorScale(d[attribute.name]));
 
-        const rect = two.makeRect(barLeft, yScale(i), barLength, rowHeight);
+        const rect = two.makeRect(barLeft, yScale(i), barWidth, rowHeight);
         rect.fill = color;
 
-        // Render text labels when the space is enough
+        // Render text labels when the space is enough.
         if(rowHeight >= fontSize){
-            const text = two.makeText(textLeft, yScale(i) + rowHeight/2, barLength, rowHeight, d[attribute.name])
+            const text = two.makeText(textLeft, yScale(i) + rowHeight/2, barWidth, rowHeight, d[attribute.name])
             text.fill = d3.hsl(color).darker(3);
             text.fontsize = fontSize;
             text.align = textAlign;
@@ -76,7 +94,7 @@ export function verticalBarTrack(props) {
 
     // Draw a title of each dimension
     const titleText = `attribute: ${attribute.name} | type: ${attribute.type}`
-    const title = two.makeText(titleLeft, top, rowHeight, barWidth, titleText);
+    const title = two.makeText(titleLeft, top, rowHeight, barAreaWidth, titleText);
     title.fill = "#9A9A9A";
     title.fontsize = titleFontSize;
     title.align = isLeft ? "end" : "start";

--- a/src/VerticalBarTrack.js
+++ b/src/VerticalBarTrack.js
@@ -22,58 +22,64 @@ export function verticalBarTrack(props) {
     } = props;
 
     // Layouts and styles
-    const colWidth = 10;    // width of stacked bars
-    const xMargin = 60;     // width of text area
-    const xGap = 5;         // gap between bars and text
+    const isNominal = attribute.type === "nominal";
+    const barWidth = isNominal ? 20 : 50;
+    const textWidth = isNominal ? 50 : 20;
+    const margin = 5;
     const titleFontSize = 12;
     const fontSize = 10;
     
     // Scales
+    const valueExtent = [0, d3.extent(rowInfo.map(d => d[attribute.name]))[1]];   // zero baseline
     const yScale = d3.scaleBand()
         .domain(range(rowInfo.length))
         .range([0, height]);
+    const xScale = d3.scaleLinear()
+        .domain(valueExtent)
+        .range([0, barWidth])
     const colorScale = attribute.type === "nominal" ? 
         d3.scaleOrdinal()
             .domain(Array.from(new Set(rowInfo.map(d => d[attribute.name]))))
             .range(d3.schemeSet3) : 
         d3.scaleLinear()
-            .domain(d3.extent(rowInfo.map(d => d[attribute.name])))
+            .domain(valueExtent)
             .range([0, 1]);
     const rowHeight = yScale.bandwidth();
 
+    // Render visual components for each row (i.e., bars and texts)
+    const barLeft = left + (isLeft ? textWidth : 0);
+    const textAlign = isLeft ? "end" : "start";
+
+    rowInfo.forEach((d, i) => {
+        const barLength = isNominal ? barWidth : xScale(d[attribute.name]);
+        const textLeft = left + (isLeft ? textWidth - margin : barLength + margin);
+        const color = attribute.type === "nominal" ?
+            colorScale(d[attribute.name]) : 
+            d3.interpolateViridis(colorScale(d[attribute.name]));
+
+        const rect = two.makeRect(barLeft, yScale(i), barLength, rowHeight);
+        rect.fill = color;
+
+        // Render text labels when the space is enough
+        if(rowHeight >= fontSize){
+            const text = two.makeText(textLeft, yScale(i) + rowHeight/2, barLength, rowHeight, d[attribute.name])
+            text.fill = d3.hsl(color).darker(3);
+            text.fontsize = fontSize;
+            text.align = textAlign;
+            text.baseline = "middle";
+        }
+    });
+
     // Title
-    const titleLeft = left + (isLeft ? xGap : width - xGap);
+    const titleLeft = left + (isLeft ? margin : width - margin);
     const titleRotate = isLeft ? -Math.PI/2 : Math.PI/2;
 
     // Draw a title of each dimension
     const titleText = `attribute: ${attribute.name} | type: ${attribute.type}`
-    const title = two.makeText(titleLeft, top, rowHeight, colWidth, titleText);
+    const title = two.makeText(titleLeft, top, rowHeight, barWidth, titleText);
     title.fill = "#9A9A9A";
     title.fontsize = titleFontSize;
     title.align = isLeft ? "end" : "start";
     title.baseline = "top";
     title.rotation = titleRotate;
-
-    // Render visual components for each row (i.e., bars and texts)
-    const barLeft = left + (isLeft ? xMargin : 0);
-    const labelLeft = left + (isLeft ? xMargin - xGap : colWidth + xGap);
-    const labelAlign = isLeft ? "end" : "start";
-
-    rowInfo.forEach((d, i) => {
-        const color = attribute.type === "nominal" ?
-            colorScale(d[attribute.name]) : 
-            d3.interpolateViridis(colorScale(d[attribute.name]));
-
-        const rect = two.makeRect(barLeft, yScale(i), colWidth, rowHeight);
-        rect.fill = color;
-
-        // Render text labels when the space is enough
-        if(rowHeight >= fontSize){
-            const text = two.makeText(labelLeft, yScale(i) + rowHeight/2, colWidth, rowHeight, d[attribute.name])
-            text.fill = d3.hsl(color).darker(3);
-            text.fontsize = fontSize;
-            text.align = labelAlign;
-            text.baseline = "middle";
-        }
-    });
 }

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -25,8 +25,8 @@ const demos = {
     "Demo 2": {
         viewConfig: hgDemoViewConfig2,
         options: {
-            rowInfoPosition: "right",
-            rowLinkPosition: "left",
+            rowInfoPosition: "left",
+            rowLinkPosition: "right",
             colToolsPosition: "bottom",
             rowLinkAttribute: "url",
             rowLinkNameAttribute: "state",


### PR DESCRIPTION
I added horizontal bars for both the left and right vertical tracks (Fixes #48).

Mouse events are now simply triggered when a mouse enters the whole rectangular area of each row.

<img width="323" alt="Screen Shot 2020-02-07 at 12 51 27 PM" src="https://user-images.githubusercontent.com/9922882/74058913-003b0e80-49b5-11ea-97ef-d5c217e5af2b.png">

<img width="260" alt="Screen Shot 2020-02-07 at 2 16 03 PM" src="https://user-images.githubusercontent.com/9922882/74058906-fd401e00-49b4-11ea-873d-5d7edc6a14f9.png">
