### PR TITLE
Remove sort and search pubsubs

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -27,11 +27,13 @@ toc:
 - getHMSelectedRowsFromViewConfig
 - resolveIntervalCoordinates
 - selectRows
+- highlightRowsFromSearch
 - insertItemToArray
 - modifyItemInArray
 - removeItemFromArray
 - drawVisTitle
 - matrixToTree
+- createReducer
 - name: Classes (internal)
 - Two
 - TwoRectangle

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -1,17 +1,14 @@
 import React, { useRef, useEffect, useState, useMemo, useCallback, useContext } from 'react';
-import PubSub from 'pubsub-js';
 import isEqual from 'lodash/isEqual';
 
 import { HiGlassComponent } from 'higlass';
 import higlassRegister from 'higlass-register';
 import StackedBarTrack from 'higlass-multivec/es/StackedBarTrack.js';
 
-import { EVENT } from './utils/constants.js';
 import { InfoContext, ACTION } from './utils/contexts.js';
 import { selectRows, highlightRowsFromSearch } from './utils/select-rows.js';
 import TrackWrapper from './TrackWrapper.js';
 import Tooltip from './Tooltip.js';
-import TrackRowSearch from './TrackRowSearch.js';
 
 import { processWrapperOptions, getTrackWrapperOptions, updateGlobalOptionsWithKey } from './utils/options.js';
 import { 
@@ -119,46 +116,32 @@ export default function CistromeHGWConsumer(props) {
         drawRef.current[key] = drawFunction;
     }, [drawRef]);
 
-    // Process the options prop (initially, upon sorting, etc).
+    // Callback function for sorting.
+    const onSortRows = useCallback((viewId, trackId, field, type, order) => {
+        const newRowSort = [ { field, type, order } ];
+        const newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowSort, "rowSort");
+        const newOptions = processWrapperOptions(newOptionsRaw);
+
+        const trackOptions = getTrackWrapperOptions(newOptions, viewId, trackId);
+        const newSelectedRows = selectRows(context.state[viewId][trackId].rowInfo, trackOptions);
+        setTrackSelectedRows(viewId, trackId, newSelectedRows);
+        setOptions(newOptions);
+    });
+
+    const onSearchRows = useCallback((viewId, trackId, field, type, contains) => {
+        const newRowHighlight = { field, type, contains };
+        const newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowHighlight, "rowHighlight");
+        const newOptions = processWrapperOptions(newOptionsRaw);
+
+        // Highlighting options are specified only in the wrapper options.
+        const newHighlitRows = highlightRowsFromSearch(context.state[viewId][trackId].rowInfo, field, type, contains);
+        setHighlitRows(viewId, trackId, newHighlitRows);
+        setOptions(newOptions);
+    });
+
+    // Do initial processing of the options prop.
     useEffect(() => {
         setOptions(processWrapperOptions(optionsRaw));
-
-        // Row sorting options
-        const sortToken = PubSub.subscribe(EVENT.SORT, (msg, data) => {
-            const newRowSort = [{field: data.field, type: data.type, order: data.order}];
-            const newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowSort, "rowSort");
-            const newOptions = processWrapperOptions(newOptionsRaw)
-
-            const trackOptions = getTrackWrapperOptions(newOptions, data.viewId, data.trackId);
-            const newSelectedRows = selectRows(
-                context.state[data.viewId][data.trackId].rowInfo, 
-                trackOptions
-            );
-            setTrackSelectedRows(data.viewId, data.trackId, newSelectedRows);
-            setOptions(newOptions);
-        });
-
-        // Row highlighting options. 
-        const hlToken = PubSub.subscribe(EVENT.SEARCH_CHANGE, (msg, data) => {
-            const newRowHighlight = {field: data.field, type: data.type, contains: data.contains};
-            const newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowHighlight, "rowHighlight");
-            const newOptions = processWrapperOptions(newOptionsRaw)
-
-            // Highlighting options are specified only in the Wrapper options.
-            const newHighlitRows = highlightRowsFromSearch(
-                context.state[data.viewId][data.trackId].rowInfo, 
-                data.field, 
-                data.type, 
-                data.contains
-            );
-            setHighlitRows(data.viewId, data.trackId, newHighlitRows);
-            setOptions(newOptions);
-        });
-
-        return () => {
-            PubSub.unsubscribe(sortToken);
-            PubSub.unsubscribe(hlToken);
-        };
     }, [optionsRaw]);
 
     // Listen for higlass view config changes.
@@ -212,11 +195,16 @@ export default function CistromeHGWConsumer(props) {
                             onViewConfig(newViewConfig);
                         });
                     }}
+                    onSortRows={(field, type, order) => {
+                        onSortRows(viewId, trackId, field, type, order);
+                    }}
+                    onSearchRows={(field, type, contains) => {
+                        onSearchRows(viewId, trackId, field, type, contains);
+                    }}
                     drawRegister={drawRegister}
                 />
             ))}
             <Tooltip />
-            <TrackRowSearch />
         </div>
     );
 }

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -22,6 +22,8 @@ const fieldTypeToVisComponent = {
  * @prop {array} rowInfo Array of JSON objects, one object for each row.
  * @prop {array} rowInfoAttributes Array of JSON object, one object for the names and types of each attribute.
  * @prop {string} rowInfoPosition The value of the `rowInfoPosition` option.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfo(props) {
@@ -33,6 +35,8 @@ export default function TrackRowInfo(props) {
         rowInfo, 
         rowInfoAttributes,
         rowInfoPosition,
+        onSortRows,
+        onSearchRows,
         drawRegister
     } = props;
 
@@ -85,6 +89,8 @@ export default function TrackRowInfo(props) {
                     viewId: viewId,
                     trackId: trackId,
                     rowInfo: rowInfo,
+                    onSortRows: onSortRows,
+                    onSearchRows: onSearchRows,
                     drawRegister: drawRegister,
                 }
             ))}

--- a/src/TrackRowInfoControl.js
+++ b/src/TrackRowInfoControl.js
@@ -8,6 +8,8 @@ import TrackRowSearch from './TrackRowSearch.js';
 
 import './TrackRowInfoControl.scss';
 
+const LOCAL_EVENT_SEARCH_OPEN = "search-open";
+
 /**
  * Component with control buttons for each vertical track (for sorting, searching, etc).
  * @prop {boolean} isVisible The visibility of the control.
@@ -33,8 +35,10 @@ export default function TrackRowInfoControl(props){
     const controlField = (type === "url" && title ? title : field);
     const controlType = (type === "url" ? "nominal" : type);
 
+    // Subscribe to the search open events of other TrackRowInfoControl components,
+    // so that only one search is open at a time.
     useEffect(() => {
-        const searchOpenToken = PubSub.subscribe(EVENT.SEARCH_OPEN, (msg, otherDivRef) => {
+        const searchOpenToken = PubSub.subscribe(LOCAL_EVENT_SEARCH_OPEN, (msg, otherDivRef) => {
             if(divRef !== otherDivRef) {
                 setIsSearching(false);
             }
@@ -56,7 +60,7 @@ export default function TrackRowInfoControl(props){
         setSearchTop(event.clientY - parentRect.y);
         setSearchLeft(event.clientX - parentRect.x);
 
-        PubSub.publish(EVENT.SEARCH_OPEN, divRef);
+        PubSub.publish(LOCAL_EVENT_SEARCH_OPEN, divRef);
     }
     function onSearchClose() {
         setIsSearching(false);

--- a/src/TrackRowInfoControl.js
+++ b/src/TrackRowInfoControl.js
@@ -1,83 +1,101 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import PubSub from 'pubsub-js';
 
 import { EVENT } from './utils/constants.js';
 import { SEARCH, SORT_ASC, SORT_DESC } from './utils/icons.js';
+
+import TrackRowSearch from './TrackRowSearch.js';
+
 import './TrackRowInfoControl.scss';
 
 /**
  * Component with control buttons for each vertical track (for sorting, searching, etc).
- * @prop {string} viewId The viewId for the horizontal-multivec track.
- * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {boolean} isVisible The visibility of the control.
  * @prop {object} fieldInfo JSON object of the name and type of an attribute.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
  */
 export default function TrackRowInfoControl(props){
     const {
-        viewId, trackId,
         isVisible, 
         fieldInfo,
+        onSortRows,
+        onSearchRows
     } = props;
 
     const divRef = useRef();
+    const [isSearching, setIsSearching] = useState(false);
+    const [searchTop, setSearchTop] = useState(null);
+    const [searchLeft, setSearchLeft] = useState(null);
+
+    const { field, type, title } = fieldInfo;
+    console.assert(type !== "tree");
+    const controlField = (type === "url" && title ? title : field);
+    const controlType = (type === "url" ? "nominal" : type);
+
+    useEffect(() => {
+        const searchOpenToken = PubSub.subscribe(EVENT.SEARCH_OPEN, (msg, otherDivRef) => {
+            if(divRef !== otherDivRef) {
+                setIsSearching(false);
+            }
+        });
+
+        return () => PubSub.unsubscribe(searchOpenToken);
+    })
 
     function onSortAscClick() {
-        const { field, type, title } = fieldInfo;
-        if(type === "tree") return;
-        PubSub.publish(EVENT.SORT, {
-            field: (type === "url" && title ? title : field),
-            type,
-            order: "ascending",
-            viewId,
-            trackId,
-        });
+        onSortRows(controlField, controlType, "ascending");
     }
     function onSortDescClick() {
-        const { field, type, title } = fieldInfo;
-        if(type === "tree") return;
-        PubSub.publish(EVENT.SORT, {
-            field: (type === "url" && title ? title : field),
-            type,
-            order: "descending",
-            viewId,
-            trackId,
-        });
+        onSortRows(controlField, controlType, "descending");
     }
     function onSearchClick(event) {
-        const { field, type, title } = fieldInfo;
-        if(type === "tree") return;
-        const parentRect = divRef.current.closest(".cistrome-hgw").getBoundingClientRect();
-        PubSub.publish(EVENT.SEARCH_OPEN, {
-            top: event.clientY - parentRect.y,
-            left: event.clientX - parentRect.x,
-            field: (type === "url" && title ? title : field),
-            type: (type === "url" ? "nominal" : type),
-            viewId, 
-            trackId,
-        });
+        const parentRect = divRef.current.getBoundingClientRect();
+        
+        setIsSearching(true);
+        setSearchTop(event.clientY - parentRect.y);
+        setSearchLeft(event.clientX - parentRect.x);
+
+        PubSub.publish(EVENT.SEARCH_OPEN, divRef);
+    }
+    function onSearchClose() {
+        setIsSearching(false);
+    }
+    function onSearchChange(value) {
+        onSearchRows(controlField, controlType, value);
     }
 
     return (
-        <div ref={divRef}
-            className={"chgw-control"}
-            style={{
-                visibility: isVisible ? "visible" : "hidden"
-            }}>
-            <svg className="chgw-button-sm chgw-button-left"
-                onClick={onSortAscClick} viewBox={SORT_ASC.viewBox}>
-                <title>Sort rows in ascending order</title>
-                <path d={SORT_ASC.path} fill="currentColor"/>
-            </svg>
-            <svg className="chgw-button-sm chgw-button-middle"
-                onClick={onSortDescClick} viewBox={SORT_DESC.viewBox}>
-                <title>Sort rows in descending order</title>
-                <path d={SORT_DESC.path} fill="currentColor"/>
-            </svg>
-            <svg className="chgw-button-sm chgw-button-right"
-                onClick={onSearchClick} viewBox={SEARCH.viewBox}>
-                <title>Search keywords</title>
-                <path d={SEARCH.path} fill="currentColor"/>
-            </svg>
+        <div>
+            <div ref={divRef}
+                className={"chgw-control"}
+                style={{
+                    visibility: isVisible ? "visible" : "hidden"
+                }}>
+                <svg className="chgw-button-sm chgw-button-left"
+                    onClick={onSortAscClick} viewBox={SORT_ASC.viewBox}>
+                    <title>Sort rows in ascending order</title>
+                    <path d={SORT_ASC.path} fill="currentColor"/>
+                </svg>
+                <svg className="chgw-button-sm chgw-button-middle"
+                    onClick={onSortDescClick} viewBox={SORT_DESC.viewBox}>
+                    <title>Sort rows in descending order</title>
+                    <path d={SORT_DESC.path} fill="currentColor"/>
+                </svg>
+                <svg className="chgw-button-sm chgw-button-right"
+                    onClick={onSearchClick} viewBox={SEARCH.viewBox}>
+                    <title>Search keywords</title>
+                    <path d={SEARCH.path} fill="currentColor"/>
+                </svg>
+            </div>
+            {isSearching ? (
+                <TrackRowSearch 
+                    top={searchTop}
+                    left={searchLeft}
+                    onChange={onSearchChange}
+                    onClose={onSearchClose}
+                />
+            ) : null}
         </div>
     )
 }

--- a/src/TrackRowInfoVisBar.js
+++ b/src/TrackRowInfoVisBar.js
@@ -23,6 +23,8 @@ export const margin = 5;
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} viewId The viewId for the horizontal-multivec track.
  * @prop {string} trackId The trackId for the horizontal-multivec track.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfoVisBar(props) {
@@ -33,6 +35,8 @@ export default function TrackRowInfoVisBar(props) {
         viewId,
         trackId,
         rowInfo,
+        onSortRows,
+        onSearchRows,
         drawRegister,
     } = props;
 
@@ -186,13 +190,13 @@ export default function TrackRowInfoVisBar(props) {
                 }}
             />
             <TrackRowInfoControl
-                viewId={viewId}
-                trackId={trackId}
                 isLeft={isLeft}
                 isVisible={mouseX !== null}
                 fieldInfo={fieldInfo}
                 searchTop={top}
                 searchLeft={left}
+                onSortRows={onSortRows}
+                onSearchRows={onSearchRows}
             />
         </div>
     );

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -23,6 +23,8 @@ const margin = 5;
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} viewId The viewId for the horizontal-multivec track.
  * @prop {string} trackId The trackId for the horizontal-multivec track.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfoVisLink(props) {
@@ -32,6 +34,8 @@ export default function TrackRowInfoVisLink(props) {
         fieldInfo,
         isLeft,
         rowInfo,
+        onSortRows,
+        onSearchRows,
         drawRegister,
     } = props;
 
@@ -157,11 +161,11 @@ export default function TrackRowInfoVisLink(props) {
                 }}
             />
             <TrackRowInfoControl
-                viewId={viewId}
-                trackId={trackId}
                 isLeft={isLeft}
                 isVisible={mouseX !== null}
                 fieldInfo={fieldInfo}
+                onSortRows={onSortRows}
+                onSearchRows={onSearchRows}
             />
         </div>
     );

--- a/src/TrackRowSearch.js
+++ b/src/TrackRowSearch.js
@@ -5,7 +5,11 @@ import { CLOSE } from './utils/icons.js';
 import './TrackRowSearch.scss';
 
 /**
- * Text field to serach for keywords. Subscribes to 'search' event via `PubSub`.
+ * Text field to serach for keywords.
+ * @prop {number} top The top coordinate.
+ * @prop {number} left The left coordinate.
+ * @prop {function} onChange The function to call when the search keyword has changed.
+ * @prop {function} onClose The function to call when the search field should be closed.
  * @example
  * <TrackRowSearch/>
  */

--- a/src/TrackRowSearch.js
+++ b/src/TrackRowSearch.js
@@ -9,14 +9,13 @@ import './TrackRowSearch.scss';
  * @example
  * <TrackRowSearch/>
  */
-export default function TrackRowSearch() {
+export default function TrackRowSearch(props) {
 
-    const [left, setLeft] = useState(null);
-    const [top, setTop] = useState(null);
-    const [field, setField] = useState("");
-    const [type, setType] = useState("");
-    const [viewId, setViewId] = useState("");
-    const [trackId, setTrackId] = useState("");
+    const {
+        top, left,
+        onChange,
+        onClose
+    } = props;
 
     const inputRef = useRef();
 
@@ -26,39 +25,17 @@ export default function TrackRowSearch() {
     const padding = 5;
     
     useEffect(() => {
-        const searchToken = PubSub.subscribe(EVENT.SEARCH_OPEN, (msg, data) => {
-            setLeft(data.left);
-            setTop(data.top);
-            setField(data.field);
-            setType(data.type);
-            setViewId(data.viewId);
-            setTrackId(data.trackId);
-
-            inputRef.current.focus();
-        });
-
-        return () => {
-            PubSub.unsubscribe(searchToken);
-        };
+        inputRef.current.focus();
     });
 
     function onKeywordChange(e) {
         const keyword = e.target.value;
-        PubSub.publish(EVENT.SEARCH_CHANGE, {
-            contains: keyword, field, type, viewId, trackId
-        });
+        onChange(keyword);
     }
 
     function onSearchClose() {
-        setLeft(null);
-        setTop(null);
-        setField("");
-        setViewId("");
-        setTrackId("");
-
-        PubSub.publish(EVENT.SEARCH_CHANGE, {
-            contains: "", field, type, viewId, trackId
-        });
+        onChange("");
+        onClose();
     }
 
     return (

--- a/src/TrackRowSearch.js
+++ b/src/TrackRowSearch.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PubSub from 'pubsub-js';
 import { EVENT } from './utils/constants.js';
 import { CLOSE } from './utils/icons.js';
@@ -9,7 +9,7 @@ import './TrackRowSearch.scss';
  * @example
  * <TrackRowSearch/>
  */
-export default function TrackRowSearch(){
+export default function TrackRowSearch() {
 
     const [left, setLeft] = useState(null);
     const [top, setTop] = useState(null);
@@ -17,6 +17,8 @@ export default function TrackRowSearch(){
     const [type, setType] = useState("");
     const [viewId, setViewId] = useState("");
     const [trackId, setTrackId] = useState("");
+
+    const inputRef = useRef();
 
     // Styles
     const width = 180;
@@ -31,6 +33,8 @@ export default function TrackRowSearch(){
             setType(data.type);
             setViewId(data.viewId);
             setTrackId(data.trackId);
+
+            inputRef.current.focus();
         });
 
         return () => {
@@ -68,6 +72,7 @@ export default function TrackRowSearch(){
             }}
         >
             <input
+                ref={inputRef}
                 type="text"
                 name="default name"
                 placeholder="keyword"

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -22,7 +22,8 @@ import fakedata from './demo/fakedata/index.js';
  *                                are siblings of `multivecTrack` (children of the same `combined` track).
  * @prop {function} onSelectGenomicInterval The function to call upon selection of a genomic interval.
  *                                          Passed down to the `TrackColTools` component.
- * @prop {function} onSelectRowInterval The function to call upon selection of a row interval.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackWrapper(props) {
@@ -34,6 +35,8 @@ export default function TrackWrapper(props) {
         combinedTrack,
         siblingTracks,
         onSelectGenomicInterval,
+        onSortRows,
+        onSearchRows,
         drawRegister
     } = props;
 
@@ -108,6 +111,8 @@ export default function TrackWrapper(props) {
                     rowInfoAttributes={leftAttrs}
                     rowSort={options.rowSort}
                     rowInfoPosition="left"
+                    onSortRows={onSortRows}
+                    onSearchRows={onSearchRows}
                     drawRegister={drawRegister}
                 />) : null}
             {rightAttrs.length !== 0 ? 
@@ -122,6 +127,8 @@ export default function TrackWrapper(props) {
                     rowInfoAttributes={rightAttrs}
                     rowSort={options.rowSort}
                     rowInfoPosition="right"
+                    onSortRows={onSortRows}
+                    onSearchRows={onSearchRows}
                     drawRegister={drawRegister}
                 />) : null}
             {options.colToolsPosition !== "hidden" ? 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -11,8 +11,7 @@ export const TRACK_TYPE = Object.freeze({
  * Events for PubSub.
  */
 export const EVENT = Object.freeze({
-    TOOLTIP: "tooltip",
-    SEARCH_OPEN: "search-open"
+    TOOLTIP: "tooltip"
 });
 
 /*

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,9 +12,7 @@ export const TRACK_TYPE = Object.freeze({
  */
 export const EVENT = Object.freeze({
     TOOLTIP: "tooltip",
-    SORT: "sort",
-    SEARCH_OPEN: "search-open",
-    SEARCH_CHANGE: "search-change"
+    SEARCH_OPEN: "search-open"
 });
 
 /*

--- a/src/utils/select-rows.js
+++ b/src/utils/select-rows.js
@@ -3,6 +3,7 @@
  * Generate an array of selected row indices based on sort and filter options.
  * @param {object[]} rowInfo The original/full default-ordered rowInfo array.
  * @param {object} options The track options object, containing sort/filter options.
+ * @returns {(number[]|null)} The array of selected indices.
  */
 export function selectRows(rowInfo, options) {
     if(!options) {
@@ -38,4 +39,30 @@ export function selectRows(rowInfo, options) {
 
         return transformedRowInfo.map(d => d[0]);
     }
+}
+
+/**
+ * Generate an array of highlighted row indices based on search keyword information.
+ * @param {object[]} rowInfo The original/full default-ordered rowInfo array.
+ * @param {string} field The attribute on which to search.
+ * @param {string} type The data type contained in the field value.
+ * @param {string} contains The search term.
+ * @returns {number[]} The array of highlit indices.
+ */
+export function highlightRowsFromSearch(rowInfo, field, type, contains) {
+    let newHighlitRows = [];
+    if(contains === "") {
+        newHighlitRows = [];
+    } else if(type === "nominal") {
+        const rowsWithIndex = Array.from(rowInfo.entries());
+        const filteredRows = rowsWithIndex.filter(d => d[1][field].toUpperCase().includes(contains.toUpperCase()));
+        newHighlitRows = filteredRows.map(d => d[0]);
+    } else if(type === "quantitative") {
+        // TODO: Better deal with quantitative data. Need to update Wrapper options for this.
+        // refer vega filter, such as lt: https://vega.github.io/vega-lite/docs/filter.html
+        const rowsWithIndex = Array.from(rowInfo.entries());
+        const filteredRows = rowsWithIndex.filter(d => d[1][field].toString().includes(contains));
+        newHighlitRows = filteredRows.map(d => d[0]);
+    }
+    return newHighlitRows;
 }

--- a/src/utils/select-rows.js
+++ b/src/utils/select-rows.js
@@ -6,10 +6,7 @@
  * @returns {(number[]|null)} The array of selected indices.
  */
 export function selectRows(rowInfo, options) {
-    if(!options) {
-        // Null means select all rows.
-        return null;
-    } else {
+    if(options) {
         // Filter
         // ...
         
@@ -23,7 +20,7 @@ export function selectRows(rowInfo, options) {
                     // Do nothing for the "tree" type.
                 } else if(type === "quantitative") {
                     transformedRowInfo.sort((a, b) => (a[1][field] - b[1][field]) * (order === "ascending" ? 1 : -1));
-                } else {
+                } else if(type === "nominal") {
                     transformedRowInfo.sort(function(a, b) {
                         let compared = 0, categoryA = a[1][field].toUpperCase(), categoryB = b[1][field].toUpperCase();
                         if(categoryA > categoryB) {
@@ -36,9 +33,11 @@ export function selectRows(rowInfo, options) {
                 }
             });
         }
-
         return transformedRowInfo.map(d => d[0]);
     }
+
+    // Null means select all rows.
+    return null;
 }
 
 /**


### PR DESCRIPTION
This pull request does some refactoring to remove the PubSub events for sorting and searching, and replaces them with onSortRows and onSearchRows functions that are passed down to the TrackRowInfoControl components.