### PR TITLE
Reposition text fields for keyword search

### DIFF
--- a/src/TrackResizer.scss
+++ b/src/TrackResizer.scss
@@ -14,5 +14,5 @@
     box-shadow: 0 0 3px 1px #0089ff;
     background: #0089ff;
     opacity: 1;
-    transform: scale(3);
+    transform: scale(2);
 } 

--- a/src/TrackResizer.scss
+++ b/src/TrackResizer.scss
@@ -7,12 +7,12 @@
     z-index: 1;
     transform-origin: center;
     scale: 1;
-    transition: scale .15s ease, opacity .15s ease;
+    transition: transform .15s ease, opacity .15s ease;
 }
 
 .visualization-resizer:hover {
     box-shadow: 0 0 3px 1px #0089ff;
     background: #0089ff;
     opacity: 1;
-    scale: 3;
+    transform: scale(3);
 } 

--- a/src/TrackResizer.scss
+++ b/src/TrackResizer.scss
@@ -10,7 +10,8 @@
     transition: transform .15s ease, opacity .15s ease;
 }
 
-.visualization-resizer:hover {
+.visualization-resizer:hover, 
+.visualization-resizer:active {
     box-shadow: 0 0 3px 1px #0089ff;
     background: #0089ff;
     opacity: 1;

--- a/src/TrackRowSearch.js
+++ b/src/TrackRowSearch.js
@@ -48,7 +48,7 @@ export default function TrackRowSearch(props) {
             style={{
                 display: ((left !== null && top !== null) ? 'flex' : 'none'),
                 left: left - (width + padding * 2) / 2,
-                top: top - (height + padding * 2) - 30,
+                top: top - (height + padding * 2) - 60,
                 padding
             }}
         >


### PR DESCRIPTION
I repositioned text fields for keyword search not to overlap vertical tracks, which is caused by using 'vertical' arrangement for three buttons.

I also added css styles that make the resizer component bigger on mouse hover.