### PR TITLE
Add description in title for sorting status

### DIFF
--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -37,6 +37,7 @@ export default function TrackRowInfo(props) {
         rowInfo, 
         rowInfoAttributes,
         rowInfoPosition,
+        rowSort,
         onSortRows,
         onSearchRows,
         drawRegister
@@ -69,11 +70,14 @@ export default function TrackRowInfo(props) {
     rowInfoAttributes.forEach((attribute, i) => {
         const fieldInfo = isLeft ? rowInfoAttributes[rowInfoAttributes.length - i - 1] : attribute;
         const width = widths.find(d => d.field === fieldInfo.field && d.type === fieldInfo.type).width;
+        const sortInfo = rowSort.find(d => d.field === fieldInfo.field);
+        let sortOrder = sortInfo ? sortInfo.order : null;
 
         trackProps.push({
             left: currentLeft, top: 0, width, height,
             fieldInfo,
-            isLeft
+            isLeft,
+            sortOrder
         });
         currentLeft += width;
     });
@@ -152,6 +156,7 @@ export default function TrackRowInfo(props) {
                     viewId: viewId,
                     trackId: trackId,
                     rowInfo: rowInfo,
+                    sortOrder: d.sortOrder,
                     onSortRows: onSortRows,
                     onSearchRows: onSearchRows,
                     drawRegister: drawRegister,

--- a/src/TrackRowInfoVisBar.js
+++ b/src/TrackRowInfoVisBar.js
@@ -21,6 +21,7 @@ export const margin = 5;
  * @prop {object[]} rowInfo Array of JSON objects, one object for each row.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
+ * @prop {string} sortOrder The order of sort applied in this track. If sort is not applied, then null.
  * @prop {string} viewId The viewId for the horizontal-multivec track.
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
@@ -35,6 +36,7 @@ export default function TrackRowInfoVisBar(props) {
         viewId,
         trackId,
         rowInfo,
+        sortOrder,
         onSortRows,
         onSearchRows,
         drawRegister,
@@ -60,7 +62,7 @@ export default function TrackRowInfoVisBar(props) {
             domElement
         });
 
-        drawVisTitle(field, { two, isLeft, isNominal, width });
+        drawVisTitle(field, { two, isLeft, isNominal, width, sortOrder });
 
         const textAreaWidth = isNominal ? width - 20 : 20;
         const barAreaWidth = width - textAreaWidth;

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -21,6 +21,7 @@ const margin = 5;
  * @prop {object[]} rowInfo Array of JSON objects, one object for each row.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
+ * @prop {string} sortOrder The order of sort applied in this track. If sort is not applied, then null.
  * @prop {string} viewId The viewId for the horizontal-multivec track.
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
@@ -34,6 +35,7 @@ export default function TrackRowInfoVisLink(props) {
         fieldInfo,
         isLeft,
         rowInfo,
+        sortOrder,
         onSortRows,
         onSearchRows,
         drawRegister,
@@ -65,7 +67,7 @@ export default function TrackRowInfoVisLink(props) {
             domElement
         });
 
-        drawVisTitle(field, { two, isLeft, isNominal, width });
+        drawVisTitle(field, { two, isLeft, isNominal, width, sortOrder });
 
         if(rowHeight < fontSize) {
             // Bail out if there is not enough height per row to render links.

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -22,9 +22,9 @@ const demos = {
                 {field: "Tissue Type", type: "nominal", position: "right"}
             ],
             rowSort: [
-                {field: "Species", type: "nominal", order: "ascending"},
-                {field: "Tissue Type", type: "nominal", order: "ascending"},
-                {field: "Cell Type", type: "nominal", order: "ascending"}
+                // {field: "Species", type: "nominal", order: "ascending"},
+                // {field: "Tissue Type", type: "nominal", order: "ascending"},
+                // {field: "Cell Type", type: "nominal", order: "ascending"}
             ]
         }
     },
@@ -40,8 +40,8 @@ const demos = {
                 {field: "Tissue Type", type: "nominal", position: "right"}
             ],
             rowSort: [
-                {field: "Tissue Type", type: "nominal", order: "ascending"},
-                {field: "Random 2", type: "quantitative", order: "descending"}
+                // {field: "Tissue Type", type: "nominal", order: "ascending"},
+                // {field: "Random 2", type: "quantitative", order: "descending"}
             ]
         }
     },

--- a/src/utils/vis.js
+++ b/src/utils/vis.js
@@ -10,15 +10,16 @@
  * @param {number} options.width Width of this view.
  */
 export function drawVisTitle(text, options) {
-    const { two, isLeft, isNominal, width } = options;
+    const { two, isLeft, isNominal, width, sortOrder } = options;
     
     const margin = 5;
     const barAreaWidth = isNominal ? 20 : width - 20;
     const titleFontSize = 12;
     const titleLeft = (isLeft ? margin : width - margin);
     const titleRotate = isLeft ? -Math.PI/2 : Math.PI/2;
+    const fullText = sortOrder ? `${text} | sorted (${sortOrder})` : text;
 
-    const title = two.makeText(titleLeft, 0, 12, barAreaWidth, text);
+    const title = two.makeText(titleLeft, 0, 12, barAreaWidth, fullText);
     title.fill = "#9A9A9A";
     title.fontsize = titleFontSize;
     title.align = isLeft ? "end" : "start";


### PR DESCRIPTION
I added textual descriptions about sorting status in the title of vertical tracks.

In the future, we can add icons for indicating the sorting (and filtering) status and even give some interactions on that components. However, I think we are fine with this textual description for now.

<img width="167" alt="image" src="https://user-images.githubusercontent.com/9922882/74854112-de268200-530c-11ea-980f-b56d017c5de8.png">


This fixes #66.