### PR TITLE
Add indicator for filtered status

### DIFF
--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -24,6 +24,8 @@ const fieldTypeToVisComponent = {
  * @prop {array} rowInfo Array of JSON objects, one object for each row.
  * @prop {array} rowInfoAttributes Array of JSON object, one object for the names and types of each attribute.
  * @prop {string} rowInfoPosition The value of the `rowInfoPosition` option.
+ * @prop {object} rowSort The options for sorting rows.
+ * @prop {object} rowFilter The options for filtering rows.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
@@ -38,6 +40,7 @@ export default function TrackRowInfo(props) {
         rowInfoAttributes,
         rowInfoPosition,
         rowSort,
+        rowFilter,
         onSortRows,
         onSearchRows,
         onFilter,
@@ -71,14 +74,23 @@ export default function TrackRowInfo(props) {
     rowInfoAttributes.forEach((attribute, i) => {
         const fieldInfo = isLeft ? rowInfoAttributes[rowInfoAttributes.length - i - 1] : attribute;
         const width = widths.find(d => d.field === fieldInfo.field && d.type === fieldInfo.type).width;
-        const sortInfo = rowSort.find(d => d.field === fieldInfo.field);
-        let sortOrder = sortInfo ? sortInfo.order : null;
+        
+        // Title suffix.
+        let titleSuffix = "";
+        const sortInfo = rowSort ? rowSort.find(d => d.field === fieldInfo.field) : undefined;
+        if(sortInfo) {
+            titleSuffix += ` | sort (${sortInfo.order})`;
+        }
+        const filterInfo = rowFilter ? rowFilter.filter(d => d.field === fieldInfo.field) : undefined;
+        if(filterInfo && filterInfo.length > 0) {
+            titleSuffix += ` | filter (${filterInfo.map(d => `"${d.contains}"`).join(', ')})`;
+        }
 
         trackProps.push({
             left: currentLeft, top: 0, width, height,
             fieldInfo,
             isLeft,
-            sortOrder
+            titleSuffix
         });
         currentLeft += width;
     });
@@ -157,7 +169,7 @@ export default function TrackRowInfo(props) {
                     viewId,
                     trackId,
                     transformedRowInfo,
-                    sortOrder: d.sortOrder,
+                    titleSuffix: d.titleSuffix,
                     onSortRows,
                     onSearchRows,
                     onFilter,

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -79,11 +79,11 @@ export default function TrackRowInfo(props) {
         let titleSuffix = "";
         const sortInfo = rowSort ? rowSort.find(d => d.field === fieldInfo.field) : undefined;
         if(sortInfo) {
-            titleSuffix += ` | sort (${sortInfo.order})`;
+            titleSuffix += ` | sorted (${sortInfo.order})`;
         }
         const filterInfo = rowFilter ? rowFilter.filter(d => d.field === fieldInfo.field) : undefined;
         if(filterInfo && filterInfo.length > 0) {
-            titleSuffix += ` | filter (${filterInfo.map(d => `"${d.contains}"`).join(', ')})`;
+            titleSuffix += ` | filtered by ${filterInfo.map(d => `"${d.contains}"`).join(', ')}`;
         }
 
         trackProps.push({

--- a/src/TrackRowInfoVisBar.js
+++ b/src/TrackRowInfoVisBar.js
@@ -21,7 +21,7 @@ export const margin = 5;
  * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
- * @prop {string} sortOrder The order of sort applied in this track. If sort is not applied, then null.
+ * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
  * @prop {string} viewId The viewId for the horizontal-multivec track.
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.

--- a/src/TrackRowInfoVisBar.js
+++ b/src/TrackRowInfoVisBar.js
@@ -36,7 +36,7 @@ export default function TrackRowInfoVisBar(props) {
         viewId,
         trackId,
         transformedRowInfo,
-        sortOrder,
+        titleSuffix,
         onSortRows,
         onSearchRows,
         onFilter,
@@ -63,7 +63,7 @@ export default function TrackRowInfoVisBar(props) {
             domElement
         });
 
-        drawVisTitle(field, { two, isLeft, isNominal, width, sortOrder });
+        drawVisTitle(field, { two, isLeft, isNominal, width, titleSuffix });
 
         const textAreaWidth = isNominal ? width - 20 : 20;
         const barAreaWidth = width - textAreaWidth;

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -35,7 +35,7 @@ export default function TrackRowInfoVisLink(props) {
         fieldInfo,
         isLeft,
         transformedRowInfo,
-        sortOrder,
+        titleSuffix,
         onSortRows,
         onSearchRows,
         onFilter,
@@ -68,7 +68,7 @@ export default function TrackRowInfoVisLink(props) {
             domElement
         });
 
-        drawVisTitle(field, { two, isLeft, isNominal, width, sortOrder });
+        drawVisTitle(field, { two, isLeft, isNominal, width, titleSuffix });
 
         if(rowHeight < fontSize) {
             // Bail out if there is not enough height per row to render links.

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -21,7 +21,7 @@ const margin = 5;
  * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
- * @prop {string} sortOrder The order of sort applied in this track. If sort is not applied, then null.
+ * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
  * @prop {string} viewId The viewId for the horizontal-multivec track.
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -112,6 +112,7 @@ export default function TrackWrapper(props) {
                     trackWidth={trackWidth}
                     rowInfoAttributes={leftAttrs}
                     rowSort={options.rowSort}
+                    rowFilter={options.rowFilter}
                     rowInfoPosition="left"
                     onSortRows={onSortRows}
                     onSearchRows={onSearchRows}
@@ -129,6 +130,7 @@ export default function TrackWrapper(props) {
                     trackWidth={trackWidth}
                     rowInfoAttributes={rightAttrs}
                     rowSort={options.rowSort}
+                    rowFilter={options.rowFilter}
                     rowInfoPosition="right"
                     onSortRows={onSortRows}
                     onSearchRows={onSearchRows}

--- a/src/utils/vis.js
+++ b/src/utils/vis.js
@@ -8,6 +8,7 @@
  * @param {boolean} options.isLeft In this view placed on the left side of the track?
  * @param {boolean} options.isNominal Is this view visualizes a nominal value?
  * @param {number} options.width Width of this view.
+ * @param {string} options.titleSuffix The suffix of a title, information about sorting and filtering status.
  */
 export function drawVisTitle(text, options) {
     const { two, isLeft, isNominal, width, titleSuffix } = options;

--- a/src/utils/vis.js
+++ b/src/utils/vis.js
@@ -10,14 +10,14 @@
  * @param {number} options.width Width of this view.
  */
 export function drawVisTitle(text, options) {
-    const { two, isLeft, isNominal, width, sortOrder } = options;
+    const { two, isLeft, isNominal, width, titleSuffix } = options;
     
     const margin = 5;
     const barAreaWidth = isNominal ? 20 : width - 20;
     const titleFontSize = 12;
     const titleLeft = (isLeft ? margin : width - margin);
     const titleRotate = isLeft ? -Math.PI/2 : Math.PI/2;
-    const fullText = sortOrder ? `${text} | sorted (${sortOrder})` : text;
+    const fullText = text + titleSuffix;
 
     const title = two.makeText(titleLeft, 0, 12, barAreaWidth, fullText);
     title.fill = "#9A9A9A";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9922882/74972260-62513600-53ef-11ea-9ee8-3e78c4842921.png)

Added textual descriptions about the filtering status, just like the one for the sorting status.

This fixes #81 