### PR TITLE
Add stacked bar chart for multiple quantitative fields

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -9,7 +9,8 @@ toc:
 - TrackRowInfoControl
 - TrackRowHighlight
 - TrackRowInfo
-- TrackRowInfoVisBar
+- TrackRowInfoVisNominalBar
+- TrackRowInfoVisQuantitativeBar
 - TrackRowInfoVisDendrogram
 - TrackRowInfoVisLink
 - TrackRowSearch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added a mechanism to sort rows of a HiGrass `horizontal-multivec` track and vertical tracks on the left and right sides which is activated when users click on sorting buttons.
 - Added a feature to interactively highlight rows by typing keywords on a text field which appears when a search button is clicked.
 - Added a feature to interactively resize the width of each vertical track by dragging resizers.
+- Added a feature to interactively filter rows by keywords and reset all filters.
 
 ### Changed
 - Moved to rendering the row info categorical metadata on a single `<canvas/>` element, rather than colored HTML elements for each row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added a feature to interactively highlight rows by typing keywords on a text field which appears when a search button is clicked.
 - Added a feature to interactively resize the width of each vertical track by dragging resizers.
 - Added a feature to interactively filter rows by keywords and reset all filters.
+- Added an option to specify multiple data fields in a single vertical track and implemented stacked bar charts for this case.
 
 ### Changed
 - Moved to rendering the row info categorical metadata on a single `<canvas/>` element, rather than colored HTML elements for each row.

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -154,6 +154,8 @@ export default function CistromeHGWConsumer(props) {
 
     // Callback function for searching.
     const onSearchRows = useCallback((viewId, trackId, field, type, contains) => {
+        // TODO: Better handle with multiple fields & quantitative fields.
+        if(Array.isArray(field)) return;
         const newRowHighlight = { field, type, contains };
         const newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowHighlight, "rowHighlight", { isReplace: true });
         const newOptions = processWrapperOptions(newOptionsRaw);

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -74,7 +74,13 @@ export default function TrackRowInfo(props) {
     let trackProps = [], currentLeft = 0;
     rowInfoAttributes.forEach((attribute, i) => {
         const fieldInfo = isLeft ? rowInfoAttributes[rowInfoAttributes.length - i - 1] : attribute;
-        const width = widths.find(d => d.field === fieldInfo.field && d.type === fieldInfo.type).width;
+        const width = widths.find(d => {
+            if(Array.isArray(d.field) && Array.isArray(fieldInfo.field)) {
+                return d.field.join() === fieldInfo.field.join() && d.type === fieldInfo.type;
+            } else {
+                return d.field === fieldInfo.field && d.type === fieldInfo.type;
+            }
+        }).width;
         
         // Title suffix.
         let titleSuffix = "";

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -138,7 +138,13 @@ export default function TrackRowInfo(props) {
                 if(newWidth < minWidth) {
                     newWidth = minWidth;
                 }
-                const mIdx = widths.indexOf(widths.find(d => d.field === field && d.type === type));
+                const mIdx = widths.indexOf(widths.find(d => {
+                    if(Array.isArray(d.field) && Array.isArray(field)) {
+                        return d.field.join() === field.join() && d.type === type;
+                    } else {
+                        return d.field === field && d.type === type;
+                    }
+                }));
                 if(mIdx !== -1){
                     setWidths(modifyItemInArray(widths, mIdx, {
                         field, type,

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -1,14 +1,15 @@
 import React, { useRef, createRef, useState, useEffect} from 'react';
 import d3 from './utils/d3.js';
 import { modifyItemInArray } from './utils/array.js';
-import TrackRowInfoVisBar from './TrackRowInfoVisBar.js';
+import TrackRowInfoVisNominalBar from './TrackRowInfoVisNominalBar.js';
+import TrackRowInfoVisQuantitativeBar from './TrackRowInfoVisQuantitativeBar.js';
 import TrackRowInfoVisLink from './TrackRowInfoVisLink.js';
 import TrackRowInfoVisDendrogram from './TrackRowInfoVisDendrogram.js';
 import './TrackResizer.scss';
 
 const fieldTypeToVisComponent = {
-    "nominal": TrackRowInfoVisBar,
-    "quantitative": TrackRowInfoVisBar,
+    "nominal": TrackRowInfoVisNominalBar,
+    "quantitative": TrackRowInfoVisQuantitativeBar,
     "url": TrackRowInfoVisLink,
     "tree": TrackRowInfoVisDendrogram
 };

--- a/src/TrackRowInfoControl.scss
+++ b/src/TrackRowInfoControl.scss
@@ -29,8 +29,8 @@
 }
 
 .chgw-button-alert {
-    height: 40px;
-    width: 40px;
+    height: 35px;
+    width: 35px;
     padding: 4px;
     color: #cacaca;
 }

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -191,8 +191,8 @@ export default function TrackRowInfoVisDendrogram(props) {
                     style={{
                         position: "absolute",
                         pointerEvents: "none",
-                        top: `${height / 2.0 - 25}px`,
-                        left: `${width / 2.0 - 25}px`,
+                        top: `${height / 2.0 - 17}px`,
+                        left: `${width / 2.0 - 17}px`,
                     }}
                 >
                     <svg 

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -28,7 +28,7 @@ export const margin = 5;
  * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
-export default function TrackRowInfoVisBar(props) {
+export default function TrackRowInfoVisNominalBar(props) {
     const {
         left, top, width, height,
         fieldInfo,
@@ -48,8 +48,7 @@ export default function TrackRowInfoVisBar(props) {
     const [mouseX, setMouseX] = useState(null);
 
     // Data, layouts and styles
-    const { field, type } = fieldInfo;
-    const isNominal = type === "nominal";
+    const { field } = fieldInfo;
 
     const yScale = d3.scaleBand()
         .domain(range(transformedRowInfo.length))
@@ -63,9 +62,10 @@ export default function TrackRowInfoVisBar(props) {
             domElement
         });
 
-        drawVisTitle(field, { two, isLeft, isNominal, width, titleSuffix });
+        const titleText = Array.isArray(field) ? field.join(" + ") : field;
+        drawVisTitle(titleText, { two, isLeft, isNominal: true, width, titleSuffix });
 
-        const textAreaWidth = isNominal ? width - 20 : 20;
+        const textAreaWidth = width - 20;
         const barAreaWidth = width - textAreaWidth;
         const minTrackWidth = 40;
         const isTextLabel = width > minTrackWidth;
@@ -78,13 +78,9 @@ export default function TrackRowInfoVisBar(props) {
             .domain(valueExtent)
             .range([0, barAreaWidth]);
 
-        const colorScale = isNominal ? 
-            d3.scaleOrdinal()
+        const colorScale = d3.scaleOrdinal()
                 .domain(Array.from(new Set(transformedRowInfo.map(d => d[field]))).sort()) 
-                .range(d3.schemeSet3) : 
-            d3.scaleLinear()
-                .domain(valueExtent)
-                .range([0, 1]);
+                .range(d3.schemeSet3);
     
 
         // Render visual components for each row (i.e., bars and texts).
@@ -93,7 +89,7 @@ export default function TrackRowInfoVisBar(props) {
 
         transformedRowInfo.forEach((d, i) => {
             // To aggregate bars, check if there is a same category on the next row.
-            if(type === "nominal" && i + 1 < transformedRowInfo.length && d[field] === transformedRowInfo[i+1][field]) {
+            if(i + 1 < transformedRowInfo.length && d[field] === transformedRowInfo[i+1][field]) {
                 if(aggregateStartIdx === -1) {
                     aggregateStartIdx = i;
                 }
@@ -103,11 +99,10 @@ export default function TrackRowInfoVisBar(props) {
 
             const barTop = aggregateStartIdx !== -1 ? yScale(aggregateStartIdx) : yScale(i);
             const barHeight = rowHeight * sameCategoriesNearby;
-            const barWidth = isNominal ? barAreaWidth : xScale(d[field]);        
+            const barWidth = barAreaWidth;
             const barLeft = (isLeft ? width - barWidth : 0);
             const textLeft = (isLeft ? width - barWidth - margin : barWidth + margin);
-            const color = isNominal ? colorScale(d[field]) : 
-                d3.interpolateViridis(colorScale(d[field]));
+            const color = colorScale(d[field]);
 
             const rect = two.makeRect(barLeft, barTop, barWidth, barHeight);
             rect.fill = color;
@@ -130,7 +125,7 @@ export default function TrackRowInfoVisBar(props) {
         return two.teardown;
     });
     
-    drawRegister("TrackRowInfoVisBar", draw);
+    drawRegister("TrackRowInfoVisNominalBar", draw);
 
     useEffect(() => {
         const canvas = canvasRef.current;

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -80,7 +80,7 @@ export default function TrackRowInfoVisNominalBar(props) {
 
         const colorScale = d3.scaleOrdinal()
                 .domain(Array.from(new Set(transformedRowInfo.map(d => d[field]))).sort()) 
-                .range(d3.schemeSet3);
+                .range(d3.schemeTableau10);
     
 
         // Render visual components for each row (i.e., bars and texts).

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -169,7 +169,13 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             let fieldVal;
             if(y !== undefined){
                 setMouseX(true);
-                fieldVal = transformedRowInfo[y][field];
+                if(Array.isArray(field)){
+                    fieldVal = 0;
+                    field.forEach(f => fieldVal += transformedRowInfo[y][f]);
+
+                } else {
+                    fieldVal = transformedRowInfo[y][field];
+                }
             } else {
                 setMouseX(null);
                 destroyTooltip();
@@ -182,7 +188,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             PubSub.publish(EVENT.TOOLTIP, {
                 x: mouseViewportX,
                 y: mouseViewportY,
-                content: `${field}: ${fieldVal}`
+                content: Array.isArray(field) ? `${field.join(' + ')}: ${fieldVal}` : `${field}: ${fieldVal}`
             });
         });
 

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -172,7 +172,6 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
                 if(Array.isArray(field)){
                     fieldVal = 0;
                     field.forEach(f => fieldVal += transformedRowInfo[y][f]);
-
                 } else {
                     fieldVal = transformedRowInfo[y][field];
                 }

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -1,0 +1,233 @@
+import React, { useRef, useCallback, useEffect, useState } from "react";
+import range from "lodash/range";
+import PubSub from "pubsub-js";
+
+import d3 from "./utils/d3.js";
+import Two from "./utils/two.js";
+import { EVENT } from "./utils/constants.js";
+import { destroyTooltip } from "./utils/tooltip.js";
+import { drawVisTitle } from "./utils/vis.js";
+
+import TrackRowInfoControl from './TrackRowInfoControl.js';
+
+export const margin = 5;
+
+/**
+ * Component for visualization of row info quantitative or nominal attribute values.
+ * @prop {number} left The left position of this view.
+ * @prop {number} top The top position of this view.
+ * @prop {number} width The width of this view.
+ * @prop {number} height The height of this view.
+ * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object} fieldInfo The name and type of data field.
+ * @prop {boolean} isLeft Is this view on the left side of the track?
+ * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
+ * @prop {string} viewId The viewId for the horizontal-multivec track.
+ * @prop {string} trackId The trackId for the horizontal-multivec track.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} drawRegister The function for child components to call to register their draw functions.
+ */
+export default function TrackRowInfoVisQuantitativeBar(props) {
+    const {
+        left, top, width, height,
+        fieldInfo,
+        isLeft,
+        viewId,
+        trackId,
+        transformedRowInfo,
+        titleSuffix,
+        onSortRows,
+        onSearchRows,
+        onFilter,
+        drawRegister,
+    } = props;
+
+    const divRef = useRef();
+    const canvasRef = useRef();
+    const [mouseX, setMouseX] = useState(null);
+
+    // Data, layouts and styles
+    const { field } = fieldInfo;
+    const isStackedBar = Array.isArray(field);
+
+    const yScale = d3.scaleBand()
+        .domain(range(transformedRowInfo.length))
+        .range([0, height]);
+    const rowHeight = yScale.bandwidth();
+
+    const draw = useCallback((domElement) => {
+        const two = new Two({
+            width,
+            height,
+            domElement
+        });
+
+        const titleText = isStackedBar ? field.join(" + ") : field;
+        drawVisTitle(titleText, { two, isLeft, isNominal: false, width, titleSuffix });
+
+        const textAreaWidth = 20;
+        const barAreaWidth = width - textAreaWidth;
+        const minTrackWidth = 40;
+        const isTextLabel = width > minTrackWidth;
+        const fontSize = 10;
+       
+        if(isStackedBar) {
+            // Scales
+            const valueExtent = [0, d3.extent(transformedRowInfo.map(d => {
+                let sum = 0;
+                field.forEach(f => sum += d[f]);
+                return sum;
+            }))[1]];   // Zero baseline
+            const xScale = d3.scaleLinear()
+                .domain(valueExtent)
+                .range([0, barAreaWidth]);
+            const colorScale = d3.scaleOrdinal()
+                .domain(Array.from(new Set(field)).sort())
+                .range(d3.schemeTableau10);
+
+            // Render visual components for each row (i.e., bars and texts).
+            const textAlign = isLeft ? "end" : "start";
+            transformedRowInfo.forEach((d, i) => {
+                const barTop = yScale(i);
+                let currentBarLeft = (isLeft ? width : 0);
+
+                field.forEach((f, i) => {
+                    const barWidth = xScale(d[f]);    
+                    const color = colorScale(f);
+
+                    currentBarLeft += (isLeft ? -barWidth : 0);
+
+                    const rect = two.makeRect(currentBarLeft, barTop, barWidth, rowHeight);
+                    rect.fill = color;
+
+                    currentBarLeft += (isLeft ? 0 : barWidth);
+                });
+
+                // Render text labels when the space is enough.
+                if(rowHeight >= fontSize && isTextLabel) {
+                    let sum = 0;
+                    field.forEach(f => sum += d[f]);
+                    let textLeft = (isLeft ? width - xScale(sum) - margin : xScale(sum) + margin);
+                    const text = two.makeText(textLeft, barTop + rowHeight/2, textAreaWidth, rowHeight, sum);
+                    text.fill = "black";
+                    text.fontsize = fontSize;
+                    text.align = textAlign;
+                    text.baseline = "middle";
+                    text.overflow = "ellipsis";
+                }
+            });
+        } else {
+            // Scales
+            const valueExtent = [0, d3.extent(transformedRowInfo.map(d => d[field]))[1]];   // Zero baseline
+            const xScale = d3.scaleLinear()
+                .domain(valueExtent)
+                .range([0, barAreaWidth]);
+            const colorScale = d3.scaleLinear()
+                    .domain(valueExtent)
+                    .range([0, 1]);
+
+            // Render visual components for each row (i.e., bars and texts).
+            const textAlign = isLeft ? "end" : "start";
+            transformedRowInfo.forEach((d, i) => {
+                const barTop = yScale(i);
+                const barWidth = xScale(d[field]);        
+                const barLeft = (isLeft ? width - barWidth : 0);
+                const textLeft = (isLeft ? width - barWidth - margin : barWidth + margin);
+                const color = d3.interpolateViridis(colorScale(d[field]));
+
+                const rect = two.makeRect(barLeft, barTop, barWidth, rowHeight);
+                rect.fill = color;
+
+                // Render text labels when the space is enough.
+                if(rowHeight >= fontSize && isTextLabel) {
+                    const text = two.makeText(textLeft, barTop + rowHeight/2, textAreaWidth, rowHeight, d[field]);
+                    text.fill = d3.hsl(color).darker(3);
+                    text.fontsize = fontSize;
+                    text.align = textAlign;
+                    text.baseline = "middle";
+                    text.overflow = "ellipsis";
+                }
+            });
+        }
+
+        two.update();
+        return two.teardown;
+    });
+    
+    drawRegister("TrackRowInfoVisQuantitativeBar", draw);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const div = divRef.current;
+        const teardown = draw(canvas);
+
+        d3.select(canvas).on("mousemove", () => {
+            const [mouseX, mouseY] = d3.mouse(canvas);
+
+            const y = yScale.invert(mouseY);
+            let fieldVal;
+            if(y !== undefined){
+                setMouseX(true);
+                fieldVal = transformedRowInfo[y][field];
+            } else {
+                setMouseX(null);
+                destroyTooltip();
+                return;
+            }
+
+            const mouseViewportX = d3.event.clientX;
+            const mouseViewportY = d3.event.clientY;
+            
+            PubSub.publish(EVENT.TOOLTIP, {
+                x: mouseViewportX,
+                y: mouseViewportY,
+                content: `${field}: ${fieldVal}`
+            });
+        });
+
+        // Handle mouse leave.
+        d3.select(canvas).on("mouseout", destroyTooltip);
+        d3.select(div).on("mouseleave", () => setMouseX(null));
+
+        // Clean up.
+        return () => {
+            teardown();
+            d3.select(div).on("mouseleave", null);
+        };
+    }, [top, left, width, height, transformedRowInfo]);
+
+    return (
+        <div
+            ref={divRef}
+            className="cistrome-hgw-child"
+            style={{
+                top: `${top}px`,
+                left: `${left}px`, 
+                width: `${width}px`,
+                height: `${height}px`,
+            }}
+        >
+            <canvas
+                ref={canvasRef}
+                style={{
+                    top: 0,
+                    left: 0, 
+                    width: `${width}px`,
+                    height: `${height}px`,
+                    position: 'relative'
+                }}
+            />
+            <TrackRowInfoControl
+                isLeft={isLeft}
+                isVisible={mouseX !== null}
+                fieldInfo={fieldInfo}
+                searchTop={top}
+                searchLeft={left}
+                onSortRows={onSortRows}
+                onSearchRows={onSearchRows}
+                onFilter={onFilter}
+            />
+        </div>
+    );
+}

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -18,6 +18,7 @@ const demos = {
                 {field: "Hierarchical Clustering (Average)", type: "tree", position: "left"},
                 {field: "Random 1", type: "quantitative", position: "left"},
                 {field: "Random 3", type: "quantitative", position: "left"},
+                {field: ["Random 1", "Random 2", "Random 3", "Random 4"], type: "quantitative", position: "left"},
                 {field: "Hierarchical Clustering (Ward)", type: "tree", position: "right"},
                 {field: "Cell Type", type: "nominal", position: "right"},
                 {field: "Tissue Type", type: "nominal", position: "right"},
@@ -36,7 +37,6 @@ const demos = {
             colToolsPosition: "bottom",
             rowInfoAttributes: [
                 {field: "Random 2", type: "quantitative", position: "left"},
-                {field: ["Random 1", "Random 2"], type: "quantitative", position: "left"},
                 {field: "url", type: "url", position: "left", title: "Cell Type"},
                 {field: "Hierarchical Clustering", type: "tree", position: "right"},
                 {field: "Cell Type", type: "nominal", position: "right"},

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -82,7 +82,7 @@ const demos = {
 
 export default function App() {
     
-    const [selectedDemo, setSelectedDemo] = useState(Object.keys(demos)[1]);
+    const [selectedDemo, setSelectedDemo] = useState(Object.keys(demos)[0]);
 
     return (
         <div className="app">

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -23,6 +23,7 @@ const demos = {
                 {field: "Cell Type", type: "nominal", position: "right"},
                 {field: "Tissue Type", type: "nominal", position: "right"},
                 {field: "Species", type: "nominal", position: "right"},
+                {field: ["Random 1", "Random 2", "Random 3", "Random 4"], type: "quantitative", position: "right"},
             ],
             rowSort: [
                 // {field: "Species", type: "nominal", order: "ascending"},

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -36,6 +36,7 @@ const demos = {
             colToolsPosition: "bottom",
             rowInfoAttributes: [
                 {field: "Random 2", type: "quantitative", position: "left"},
+                {field: ["Random 1", "Random 2"], type: "quantitative", position: "left"},
                 {field: "url", type: "url", position: "left", title: "Cell Type"},
                 {field: "Hierarchical Clustering", type: "tree", position: "right"},
                 {field: "Cell Type", type: "nominal", position: "right"},

--- a/src/demo/App.scss
+++ b/src/demo/App.scss
@@ -4,9 +4,9 @@
 
 .container {
     border: 0px solid gray;
-    width: 70%;
+    width: 50%;
     position: relative;
-    margin-left: 15%;
+    margin-left: 25%;
     box-sizing: border-box;
 }
 

--- a/src/utils/d3.js
+++ b/src/utils/d3.js
@@ -6,7 +6,7 @@
 
 import { select } from "d3-selection";
 import { format } from "d3-format";
-import { schemeSet3, interpolateViridis } from "d3-scale-chromatic";
+import { schemeSet3, schemeTableau10, interpolateViridis } from "d3-scale-chromatic";
 import { mouse, event as d3_event } from "d3-selection";
 import { scaleLinear, scaleOrdinal, scaleThreshold } from "d3-scale";
 import { scale as vega_scale } from "vega-scale";
@@ -27,6 +27,7 @@ export default {
     select,
     format,
     schemeSet3,
+    schemeTableau10,
     interpolateViridis,
     mouse,
     scaleLinear,

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -81,7 +81,7 @@ const baseSchema = {
             "required": ["field", "order"],
             "properties": {
                 "field": {
-                    "type": "string",
+                    "type": ["string", "array"],
                     "description": "The name of a data field"
                 },
                 "type": {
@@ -101,7 +101,7 @@ const baseSchema = {
             "required": ["field", "type", "contains"],
             "properties": {
                 "field": {
-                    "type": "string",
+                    "type": ["string", "array"],
                     "description": "The name of a data field"
                 },
                 "type": {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -57,8 +57,8 @@ const baseSchema = {
             "required": ["field", "type"],
             "properties": {
                 "field": {
-                    "type": "string",
-                    "description": "The name of a data field"
+                    "type": ["string", "array"],
+                    "description": "The data field name(s)"
                 },
                 "type": {
                     "type": "string",
@@ -190,7 +190,7 @@ export function processWrapperOptions(optionsRaw) {
     // Validate the raw options:
     const valid = validateWrapperOptions(optionsRaw);
     if(!valid) {
-        console.log("Invalid Wrapper Options.");
+        console.log("WARNING: Invalid Wrapper Options.");
         return options;
     }
 

--- a/src/viewconfigs/horizontal-multivec-1.json
+++ b/src/viewconfigs/horizontal-multivec-1.json
@@ -190,7 +190,7 @@
                 "colorbarPosition": "bottomLeft"
               },
               "width": 1607,
-              "height": 482,
+              "height": 682,
               "resolutions": [
                 16384000,
                 8192000,


### PR DESCRIPTION
I implemented stacked bar charts, modifying a `fieldInfo` option to accept an array of multiple data fields for this purpose.

Sorting rows works based on the sum of multiple values.

Since we have not decided how to support filtering/highlighting for quantitative values, filtering and highlighting in this field are not supported yet.

To manage the `TrackRowInfoVisBar.js` file to be more simple, I separated it into two files: `TrackRowInfoVisQuantitativeBar.js` and `TrackRowInfoVisNominalBar.js.`

I changed the default demo as "Demo 1" because now we have filtering options and demo 1 data contains quantitative data.

![image](https://user-images.githubusercontent.com/9922882/74985382-583a3200-5405-11ea-9229-c2df629d399a.png)

Fixes #96.