### PR TITLE
Add hidden canvas for mouse events in quantitative bar charts

### DIFF
--- a/src/CistromeHGWConsumer.scss
+++ b/src/CistromeHGWConsumer.scss
@@ -9,3 +9,7 @@
 .cistrome-hgw-child {
     position: absolute;
 }
+
+.chw-hidden-canvas {
+    display: none;
+}

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -9,7 +9,7 @@ import { destroyTooltip } from "./utils/tooltip.js";
 import { drawVisTitle } from "./utils/vis.js";
 
 import TrackRowInfoControl from './TrackRowInfoControl.js';
-import { rgbToHex } from "./utils/color.js";
+import { rgbToHex, generateNexUniqueColor } from "./utils/color.js";
 import { getRetinaRatio } from './utils/canvas.js';
 
 export const margin = 5;
@@ -75,17 +75,6 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             cnt += 1;
         });
     });
-
-    // Unique color generation
-    // https://stackoverflow.com/questions/15804149/rgb-color-permutation/15804183#15804183
-    function generateNexUniqueColor(i) {
-        if(i < 16777215) {
-            return rgbToHex([i & 0xff, (i & 0xff00) >> 8, (i & 0xff0000) >> 16]);
-        } else {
-            console.log("WARNING: unique colors out of range.");
-            return "white";
-        }
-    }
 
     const draw = useCallback((domElement, isHidden) => {
         const two = new Two({

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -9,6 +9,8 @@ import { destroyTooltip } from "./utils/tooltip.js";
 import { drawVisTitle } from "./utils/vis.js";
 
 import TrackRowInfoControl from './TrackRowInfoControl.js';
+import { rgbToHex } from "./utils/color.js";
+import { getRetinaRatio } from './utils/canvas.js';
 
 export const margin = 5;
 
@@ -46,7 +48,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
     const divRef = useRef();
     const canvasRef = useRef();
     const hiddenCanvasRef = useRef();
-    const [mouseX, setMouseX] = useState(null);
+    const [isMouseHover, setIsMouseHover] = useState(null);
 
     // Data, layouts and styles
     const { field } = fieldInfo;
@@ -59,9 +61,10 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
 
     // Array to store information for mouse events, such as unique color.
     let colorToInfo = [];
-    let cnt = 0, fields = isStackedBar ? field : [field];
-    transformedRowInfo.forEach((d, i) => {
-        fields.forEach(f => {
+    let cnt = 1, fields = isStackedBar ? field : [field];
+    
+    fields.forEach(f => {
+        transformedRowInfo.forEach((d, i) => {
             const uniqueColor = generateNexUniqueColor(cnt++);
             colorToInfo.push({
                 color: uniqueColor,
@@ -69,6 +72,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
                 value: d[f],
                 rowIndex: i
             });
+            cnt += 1;
         });
     });
 
@@ -121,7 +125,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
 
                 field.forEach((f, j) => {
                     const barWidth = xScale(d[f]);
-                    const color = isHidden ? colorToInfo.find(d => d.field === f).color : colorScale(f);
+                    const color = isHidden ? colorToInfo.find(d => d.field === f && d.rowIndex === i).color : colorScale(f);
                     
                     currentBarLeft += (isLeft ? -barWidth : 0);
 
@@ -161,7 +165,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
                 const barWidth = xScale(d[field]);        
                 const barLeft = (isLeft ? width - barWidth : 0);
                 const textLeft = (isLeft ? width - barWidth - margin : barWidth + margin);
-                const color = d3.interpolateViridis(colorScale(d[field]));
+                const color = isHidden ? colorToInfo.find(d => d.rowIndex === i).color : d3.interpolateViridis(colorScale(d[field]));;
 
                 const rect = two.makeRect(barLeft, barTop, barWidth, rowHeight);
                 rect.fill = color;
@@ -193,36 +197,30 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
 
         d3.select(canvas).on("mousemove", () => {
             const [mouseX, mouseY] = d3.mouse(canvas);
-
-            const y = yScale.invert(mouseY);
-            let fieldVal;
-            if(y !== undefined){
-                setMouseX(true);
-                if(Array.isArray(field)){
-                    fieldVal = 0;
-                    field.forEach(f => fieldVal += transformedRowInfo[y][f]);
-                } else {
-                    fieldVal = transformedRowInfo[y][field];
-                }
-            } else {
-                setMouseX(null);
-                destroyTooltip();
-                return;
-            }
+            
+            const hiddenContext = hiddenCanvasRef.current.getContext('2d');
+            const ratio = getRetinaRatio(hiddenContext);
+            const uniqueColor = rgbToHex(hiddenContext.getImageData(mouseX * ratio, mouseY * ratio, 1, 1).data);
+            const hoveredInfo = colorToInfo.find(d => d.color === uniqueColor);
 
             const mouseViewportX = d3.event.clientX;
             const mouseViewportY = d3.event.clientY;
             
-            PubSub.publish(EVENT.TOOLTIP, {
-                x: mouseViewportX,
-                y: mouseViewportY,
-                content: Array.isArray(field) ? `${field.join(' + ')}: ${fieldVal}` : `${field}: ${fieldVal}`
-            });
+            if(hoveredInfo) {
+                PubSub.publish(EVENT.TOOLTIP, {
+                    x: mouseViewportX,
+                    y: mouseViewportY,
+                    content: `${hoveredInfo.field}: ${hoveredInfo.value}`
+                });
+            } else {
+                destroyTooltip();
+            }            
         });
 
-        // Handle mouse leave.
+        // Handle mouse enter and leave.
         d3.select(canvas).on("mouseout", destroyTooltip);
-        d3.select(div).on("mouseleave", () => setMouseX(null));
+        d3.select(div).on("mouseenter", () => setIsMouseHover(true));
+        d3.select(div).on("mouseleave", () => setIsMouseHover(null));
 
         // Clean up.
         return () => {
@@ -266,7 +264,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             />
             <TrackRowInfoControl
                 isLeft={isLeft}
-                isVisible={mouseX !== null}
+                isVisible={isMouseHover !== null}
                 fieldInfo={fieldInfo}
                 searchTop={top}
                 searchLeft={left}

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -9,7 +9,7 @@ import { destroyTooltip } from "./utils/tooltip.js";
 import { drawVisTitle } from "./utils/vis.js";
 
 import TrackRowInfoControl from './TrackRowInfoControl.js';
-import { rgbToHex, generateNexUniqueColor } from "./utils/color.js";
+import { rgbToHex, generateNextUniqueColor } from "./utils/color.js";
 import { getRetinaRatio } from './utils/canvas.js';
 
 export const margin = 5;
@@ -65,7 +65,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
     
     fields.forEach(f => {
         transformedRowInfo.forEach((d, i) => {
-            const uniqueColor = generateNexUniqueColor(cnt++);
+            const uniqueColor = generateNextUniqueColor(cnt++);
             colorToInfo.push({
                 color: uniqueColor,
                 field: f,
@@ -112,7 +112,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
                 const barTop = yScale(i);
                 let currentBarLeft = (isLeft ? width : 0);
 
-                field.forEach((f, j) => {
+                field.forEach(f => {
                     const barWidth = xScale(d[f]);
                     const color = isHidden ? colorToInfo.find(d => d.field === f && d.rowIndex === i).color : colorScale(f);
                     

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -6,3 +6,14 @@ export function componentToHex(c) {
 export function rgbToHex([r, g, b]) {
     return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
 }
+
+// Unique color generation
+// https://stackoverflow.com/questions/15804149/rgb-color-permutation/15804183#15804183
+export function generateNexUniqueColor(i) {
+    if(i < 16777215) {
+        return rgbToHex([i & 0xff, (i & 0xff00) >> 8, (i & 0xff0000) >> 16]);
+    } else {
+        console.log("WARNING: unique colors out of range.");
+        return "white";
+    }
+}

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,8 @@
+export function componentToHex(c) {
+    var hex = c.toString(16);
+    return hex.length == 1 ? "0" + hex : hex;
+}
+
+export function rgbToHex([r, g, b]) {
+    return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+}

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -9,7 +9,7 @@ export function rgbToHex([r, g, b]) {
 
 // Unique color generation
 // https://stackoverflow.com/questions/15804149/rgb-color-permutation/15804183#15804183
-export function generateNexUniqueColor(i) {
+export function generateNextUniqueColor(i) {
     if(i < 16777215) {
         return rgbToHex([i & 0xff, (i & 0xff00) >> 8, (i & 0xff0000) >> 16]);
     } else {


### PR DESCRIPTION
I added hidden canvas for mouse events. The offset issue was because the following line was missing:

`const ratio = getRetinaRatio(hiddenContext);`

This fixes #116.