### PR TITLE
Dendrogram filtering by clicking root node of subtree

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "ajv": "^6.11.0",
     "d3": "^5.15.0",
+    "d3-delaunay": "^5.2.1",
     "higlass-multivec": "github:higlass/higlass-multivec#es-modules-es",
     "higlass-register": "^0.1.0",
     "lodash": "^4.17.15",

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -136,7 +136,7 @@ export default function CistromeHGWConsumer(props) {
     });
 
     // Callback function for filtering.
-    const onFilter = useCallback((viewId, trackId, field, type, contains) => {
+    const onFilterRows = useCallback((viewId, trackId, field, type, contains) => {
         const isResetFilter = field === undefined;
         const newRowFilter = isResetFilter ? [] : { field, type, contains };
         let newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowFilter, "rowFilter", { isReplace: isResetFilter });
@@ -230,8 +230,8 @@ export default function CistromeHGWConsumer(props) {
                     onSearchRows={(field, type, contains) => {
                         onSearchRows(viewId, trackId, field, type, contains);
                     }}
-                    onFilter={(field, type, contains) => {
-                        onFilter(viewId, trackId, field, type, contains);
+                    onFilterRows={(field, type, contains) => {
+                        onFilterRows(viewId, trackId, field, type, contains);
                     }}
                     drawRegister={drawRegister}
                 />

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -29,6 +29,7 @@ const fieldTypeToVisComponent = {
  * @prop {object} rowFilter The options for filtering rows.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} onFilterRows The function to call upon a filter interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfo(props) {
@@ -44,7 +45,7 @@ export default function TrackRowInfo(props) {
         rowFilter,
         onSortRows,
         onSearchRows,
-        onFilter,
+        onFilterRows,
         drawRegister
     } = props;
 
@@ -185,7 +186,7 @@ export default function TrackRowInfo(props) {
                     titleSuffix: d.titleSuffix,
                     onSortRows,
                     onSearchRows,
-                    onFilter,
+                    onFilterRows,
                     drawRegister,
                 }
             ))}

--- a/src/TrackRowInfoControl.js
+++ b/src/TrackRowInfoControl.js
@@ -15,6 +15,7 @@ const LOCAL_EVENT_SEARCH_OPEN = "search-open";
  * @prop {object} fieldInfo JSON object of the name and type of an attribute.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} onFilterRows The function to call upon a filter interaction.
  */
 export default function TrackRowInfoControl(props){
     const {
@@ -22,7 +23,7 @@ export default function TrackRowInfoControl(props){
         fieldInfo,
         onSortRows,
         onSearchRows,
-        onFilter
+        onFilterRows
     } = props;
 
     const divRef = useRef();
@@ -132,7 +133,7 @@ export default function TrackRowInfoControl(props){
                     field={controlField}
                     type={controlType}
                     onChange={onSearchChange}
-                    onFilter={onFilter}
+                    onFilter={onFilterRows}
                     onClose={onSearchClose}
                 />
             ) : null}

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -1,5 +1,4 @@
 import React, { useRef, useCallback, useEffect, useState } from "react";
-import range from "lodash/range";
 import PubSub from "pubsub-js";
 
 import d3 from "./utils/d3.js";

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -187,6 +187,9 @@ export default function TrackRowInfoVisDendrogram(props) {
                 }
                 subtree.reverse();
                 onFilterRows(field, "tree", subtree);
+
+                setHighlightNodeX(null);
+                setHighlightNodeY(null);
             }
         });
 

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -26,6 +26,7 @@ const margin = 5;
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} onFilterRows The function to call upon a filter interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfoVisLink(props) {
@@ -38,7 +39,7 @@ export default function TrackRowInfoVisLink(props) {
         titleSuffix,
         onSortRows,
         onSearchRows,
-        onFilter,
+        onFilterRows,
         drawRegister,
     } = props;
 
@@ -170,7 +171,7 @@ export default function TrackRowInfoVisLink(props) {
                 fieldInfo={fieldInfo}
                 onSortRows={onSortRows}
                 onSearchRows={onSearchRows}
-                onFilter={onFilter}
+                onFilterRows={onFilterRows}
             />
         </div>
     );

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -26,6 +26,7 @@ export const margin = 5;
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} onFilterRows The function to call upon a filter interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfoVisNominalBar(props) {
@@ -39,7 +40,7 @@ export default function TrackRowInfoVisNominalBar(props) {
         titleSuffix,
         onSortRows,
         onSearchRows,
-        onFilter,
+        onFilterRows,
         drawRegister,
     } = props;
 
@@ -196,7 +197,7 @@ export default function TrackRowInfoVisNominalBar(props) {
                 searchLeft={left}
                 onSortRows={onSortRows}
                 onSearchRows={onSearchRows}
-                onFilter={onFilter}
+                onFilterRows={onFilterRows}
             />
         </div>
     );

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -24,8 +24,6 @@ export const margin = 5;
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
- * @prop {string} viewId The viewId for the horizontal-multivec track.
- * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} onFilterRows The function to call upon a filter interaction.
@@ -36,8 +34,6 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
         left, top, width, height,
         fieldInfo,
         isLeft,
-        viewId,
-        trackId,
         transformedRowInfo,
         titleSuffix,
         onSortRows,

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -26,6 +26,7 @@ export const margin = 5;
  * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} onFilterRows The function to call upon a filter interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackRowInfoVisQuantitativeBar(props) {
@@ -39,7 +40,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
         titleSuffix,
         onSortRows,
         onSearchRows,
-        onFilter,
+        onFilterRows,
         drawRegister,
     } = props;
 
@@ -231,7 +232,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
                 searchLeft={left}
                 onSortRows={onSortRows}
                 onSearchRows={onSearchRows}
-                onFilter={onFilter}
+                onFilterRows={onFilterRows}
             />
         </div>
     );

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -24,7 +24,7 @@ import fakedata from './demo/fakedata/index.js';
  *                                          Passed down to the `TrackColTools` component.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
- * @prop {function} onFilter The function to call upon a filer interaction.
+ * @prop {function} onFilterRows The function to call upon a filer interaction.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackWrapper(props) {
@@ -38,7 +38,7 @@ export default function TrackWrapper(props) {
         onSelectGenomicInterval,
         onSortRows,
         onSearchRows,
-        onFilter,
+        onFilterRows,
         drawRegister
     } = props;
 
@@ -116,7 +116,7 @@ export default function TrackWrapper(props) {
                     rowInfoPosition="left"
                     onSortRows={onSortRows}
                     onSearchRows={onSearchRows}
-                    onFilter={onFilter}
+                    onFilterRows={onFilterRows}
                     drawRegister={drawRegister}
                 />) : null}
             {rightAttrs.length !== 0 ? 
@@ -134,7 +134,7 @@ export default function TrackWrapper(props) {
                     rowInfoPosition="right"
                     onSortRows={onSortRows}
                     onSearchRows={onSearchRows}
-                    onFilter={onFilter}
+                    onFilterRows={onFilterRows}
                     drawRegister={drawRegister}
                 />) : null}
             {options.colToolsPosition !== "hidden" ? 

--- a/src/utils/d3.js
+++ b/src/utils/d3.js
@@ -13,6 +13,7 @@ import { scale as vega_scale } from "vega-scale";
 import { extent, sum } from "d3-array";
 import { hsl } from "d3-color";
 import { hierarchy, cluster } from "d3-hierarchy";
+import { Delaunay as delaunay } from "d3-delaunay";
 
 /*
  * Same as `d3.scaleBand` but also supports `invert()`.
@@ -38,5 +39,6 @@ export default {
     sum,
     hsl,
     hierarchy,
-    cluster
+    cluster,
+    delaunay
 };

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -106,11 +106,11 @@ const baseSchema = {
                 },
                 "type": {
                     "type": "string",
-                    "enum": ["nominal", "quantitative"],
+                    "enum": ["nominal", "quantitative", "tree"],
                     "description": "The data type of a field"
                 },
                 "contains": {
-                    "type": "string",
+                    "type": ["string", "array"],
                     "description": "The substring to search for"
                 }
             }

--- a/src/utils/select-rows.js
+++ b/src/utils/select-rows.js
@@ -26,11 +26,14 @@ export function selectRows(rowInfo, options) {
                     } else {
                         filteredRowInfo = filteredRowInfo.filter(d => d[1][field].toString().includes(contains));
                     }
+                } else if(type === "tree") {
+                    filteredRowInfo = filteredRowInfo.filter(d => d[1][field].reduce((a, h, i) => a && (i >= contains.length || h === contains[i]), true));
                 }
             });
         }
+
         // Sort
-        let transformedRowInfo = Array.from(filteredRowInfo);
+        let transformedRowInfo = filteredRowInfo;
         if(options.rowSort && options.rowSort.length > 0) {
             let sortOptions = options.rowSort.slice().reverse();
             sortOptions.forEach((d) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,6 +3827,13 @@ d3-contour@1:
   dependencies:
     d3-array "^1.1.1"
 
+d3-delaunay@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-5.2.1.tgz#0c4b280eb00194986ac4a3df9c81d32bf216cb36"
+  integrity sha512-ZZdeJl6cKRyqYVFYK+/meXvWIrAvZsZTD7WSxl4OPXCmuXNgDyACAClAJHD63zL25TA+IJGURUNO7rFseNFCYw==
+  dependencies:
+    delaunator "4"
+
 d3-dispatch@1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
@@ -4179,6 +4186,11 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
+delaunator@4:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
+  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
 
 delayed-stream@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Implements filtering of the dendrogram by clicking near a node to select the subtree containing its descendants. Uses https://github.com/d3/d3-delaunay to locate the node closest to the mouse click.

Also, I renamed the `onFilter` function to `onFilterRows` to match the `onSortRows` and `onSearchRows` functions and just to be more explicit about what is being filtered.

Fixes #97 

