### PR TITLE
Support initial sorting, filtering, and highlighting options

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -19,7 +19,7 @@ toc:
 - name: Functions (internal)
 - validateWrapperOptions
 - processWrapperOptions
-- updateGlobalOptionsWithKey
+- updateWrapperOptions
 - getTrackWrapperOptions
 - getRetinaRatio
 - traverseViewConfig

--- a/.documentation.yml
+++ b/.documentation.yml
@@ -28,6 +28,7 @@ toc:
 - updateViewConfigOnSelectGenomicInterval
 - updateViewConfigOnSelectRowsByTrack
 - getHMSelectedRowsFromViewConfig
+- getAllViewAndTrackPairs
 - resolveIntervalCoordinates
 - selectRows
 - highlightRowsFromSearch

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -51,13 +51,13 @@ export default function CistromeHGWConsumer(props) {
     const hgRef = useRef();
     const drawRef = useRef({});
 
-    const [options, setOptions] = useState(processWrapperOptions(optionsRaw));
+    const [options, setOptions] = useState({});
     const [trackInfos, setTrackInfos] = useState([]);
     const [siblingTrackInfos, setSiblingTrackInfos] = useState({});
     
     const context = useContext(InfoContext);
 
-    // Set initial sorting, filtering, and highlighting
+    // Set initial sorting, filtering, and highlighting.
     const onMetadataLoad = useCallback((viewId, trackId) => {
         const trackOptions = getTrackWrapperOptions(options, viewId, trackId);
         const rowInfo = context.state[viewId][trackId].rowInfo;
@@ -72,7 +72,7 @@ export default function CistromeHGWConsumer(props) {
             const newHighlitRows = highlightRowsFromSearch(rowInfo, field, type, contains);
             setHighlitRows(viewId, trackId, newHighlitRows);
         }
-    });
+    }, [options]);
 
     /*
      * Function to call when the view config has changed.
@@ -99,8 +99,6 @@ export default function CistromeHGWConsumer(props) {
                     selectedRows: newSelectedRows
                 });
             }
-
-            // TODO: dispatch for highlighting
         }
         setTrackInfos(newTrackInfos);
         setSiblingTrackInfos(newSiblingTrackInfos);
@@ -113,7 +111,7 @@ export default function CistromeHGWConsumer(props) {
         } catch(e) {
             return null;
         }
-    }, []);
+    }, [hgRef]);
 
     const setTrackSelectedRows = useCallback((viewId, trackId, selectedRows) => {
         const currViewConfig = hgRef.current.api.getViewConfig();
@@ -130,7 +128,7 @@ export default function CistromeHGWConsumer(props) {
             trackId,
             highlitRows
         });
-    });
+    }, [hgRef]);
 
     // Function for child components to call to "register" their draw functions.
     const drawRegister = useCallback((key, drawFunction) => {
@@ -147,7 +145,7 @@ export default function CistromeHGWConsumer(props) {
 
         setTrackSelectedRows(viewId, trackId, newSelectedRows);
         setOptions(newOptions);
-    });
+    }, [options]);
 
     // Callback function for searching and highlighting.
     const onSearchRows = useCallback((viewId, trackId, field, type, contains) => {
@@ -160,7 +158,7 @@ export default function CistromeHGWConsumer(props) {
         const newHighlitRows = highlightRowsFromSearch(context.state[viewId][trackId].rowInfo, field, type, contains);
         setHighlitRows(viewId, trackId, newHighlitRows);
         setOptions(newOptions);
-    });
+    }, [options]);
 
     // Callback function for filtering.
     const onFilterRows = useCallback((viewId, trackId, field, type, contains) => {
@@ -175,7 +173,7 @@ export default function CistromeHGWConsumer(props) {
         setHighlitRows(viewId, trackId, undefined);
         setTrackSelectedRows(viewId, trackId, newSelectedRows);
         setOptions(newOptions);
-    });
+    }, [options]);
 
     // Do initial processing of the options prop.
     useEffect(() => {

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -57,6 +57,23 @@ export default function CistromeHGWConsumer(props) {
     
     const context = useContext(InfoContext);
 
+    // Set initial sorting, filtering, and highlighting
+    const onMetadataLoad = useCallback((viewId, trackId) => {
+        const trackOptions = getTrackWrapperOptions(options, viewId, trackId);
+        const rowInfo = context.state[viewId][trackId].rowInfo;
+        
+        // Filter and sort.
+        const newSelectedRows = selectRows(rowInfo, trackOptions);
+        setTrackSelectedRows(viewId, trackId, newSelectedRows);
+        
+        // Highlight.
+        if(trackOptions.rowHighlight) {
+            const { field, type, contains } = trackOptions.rowHighlight;
+            const newHighlitRows = highlightRowsFromSearch(rowInfo, field, type, contains);
+            setHighlitRows(viewId, trackId, newHighlitRows);
+        }
+    });
+
     /*
      * Function to call when the view config has changed.
      * Updates the array of `horizontal-multivec` track IDs.
@@ -224,6 +241,9 @@ export default function CistromeHGWConsumer(props) {
                     }}
                     onFilterRows={(field, type, contains) => {
                         onFilterRows(viewId, trackId, field, type, contains);
+                    }}
+                    onMetadataLoad={() => {
+                        onMetadataLoad(viewId, trackId);
                     }}
                     drawRegister={drawRegister}
                 />

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -140,7 +140,8 @@ export default function CistromeHGWConsumer(props) {
         const isResetFilter = field === undefined;
         const newRowFilter = isResetFilter ? [] : { field, type, contains };
         let newOptionsRaw = updateGlobalOptionsWithKey(optionsRaw, newRowFilter, "rowFilter", { isReplace: isResetFilter });
-        newOptionsRaw = updateGlobalOptionsWithKey(newOptionsRaw, undefined, "rowHighlight", { isReplace: true });    // Reset highlight as well.
+        // Reset highlight as well.
+        newOptionsRaw = updateGlobalOptionsWithKey(newOptionsRaw, undefined, "rowHighlight", { isReplace: true });
         const newOptions = processWrapperOptions(newOptionsRaw);
 
         const trackOptions = getTrackWrapperOptions(newOptions, viewId, trackId);

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -43,6 +43,7 @@ export default function TrackRowInfo(props) {
         rowInfoPosition,
         rowSort,
         rowFilter,
+        rowHighlight,
         onSortRows,
         onSearchRows,
         onFilterRows,
@@ -92,6 +93,9 @@ export default function TrackRowInfo(props) {
         const filterInfo = rowFilter ? rowFilter.filter(d => d.field === fieldInfo.field) : undefined;
         if(filterInfo && filterInfo.length > 0) {
             titleSuffix += ` | filtered by ${filterInfo.map(d => `"${d.contains}"`).join(', ')}`;
+        }
+        if(rowHighlight && rowHighlight.field === fieldInfo.field) {
+            titleSuffix += ` | highlighted by "${rowHighlight.contains}"`;
         }
 
         trackProps.push({

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -1,5 +1,4 @@
-import React, { useContext } from 'react';
-import range from 'lodash/range';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { InfoContext, ACTION } from "./utils/contexts.js";
 import TrackColTools from './TrackColTools.js';
@@ -45,6 +44,14 @@ export default function TrackWrapper(props) {
 
     const context = useContext(InfoContext);
 
+    const [shouldCallOnMetadataLoad, setShouldCallOnMetadataLoad] = useState(false);
+
+    useEffect(() => {
+        if(shouldCallOnMetadataLoad) {
+            onMetadataLoad();
+        }
+    }, [shouldCallOnMetadataLoad, multivecTrackViewId, multivecTrackTrackId]);
+
     if(!multivecTrack || !multivecTrack.tilesetInfo || !multivecTrack.tilesetInfo.shape) {
         // The track or track tileset info has not yet loaded.
         return null;
@@ -80,7 +87,7 @@ export default function TrackWrapper(props) {
                 trackId: multivecTrackTrackId,
                 rowInfo: rowInfo
             });
-            onMetadataLoad();
+            setShouldCallOnMetadataLoad(true);
         }
     } catch(e) {
         console.log(e);

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -39,6 +39,7 @@ export default function TrackWrapper(props) {
         onSortRows,
         onSearchRows,
         onFilterRows,
+        onMetadataLoad,
         drawRegister
     } = props;
 
@@ -58,8 +59,6 @@ export default function TrackWrapper(props) {
     const trackWidth = multivecTrack.dimensions[0];
     const trackHeight = multivecTrack.dimensions[1];
     const totalNumRows = multivecTrack.tilesetInfo.shape[1];
-
-
 
     // Attempt to obtain metadata values from the `tilesetInfo` field of the track.
     let rowInfo = [];
@@ -81,6 +80,7 @@ export default function TrackWrapper(props) {
                 trackId: multivecTrackTrackId,
                 rowInfo: rowInfo
             });
+            onMetadataLoad();
         }
     } catch(e) {
         console.log(e);

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -113,6 +113,7 @@ export default function TrackWrapper(props) {
                     rowInfoAttributes={leftAttrs}
                     rowSort={options.rowSort}
                     rowFilter={options.rowFilter}
+                    rowHighlight={options.rowHighlight}
                     rowInfoPosition="left"
                     onSortRows={onSortRows}
                     onSearchRows={onSearchRows}
@@ -131,6 +132,7 @@ export default function TrackWrapper(props) {
                     rowInfoAttributes={rightAttrs}
                     rowSort={options.rowSort}
                     rowFilter={options.rowFilter}
+                    rowHighlight={options.rowHighlight}
                     rowInfoPosition="right"
                     onSortRows={onSortRows}
                     onSearchRows={onSearchRows}

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -26,7 +26,7 @@ const demos = {
                 {field: ["Random 1", "Random 2", "Random 3", "Random 4"], type: "quantitative", position: "right"},
             ],
             rowSort: [
-                // {field: "Cell Type", type: "nominal", order: "ascending"}
+                {field: "Cell Type", type: "nominal", order: "ascending"}
             ]
         }
     },

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -8,7 +8,6 @@ import hgDemoViewConfig3 from '../viewconfigs/horizontal-multivec-4.json';
 
 
 import './App.scss';
-import { getAllViewAndTrackPairs } from '../utils/viewconf.js';
 
 const demos = {
     "Demo 1": {

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -8,6 +8,7 @@ import hgDemoViewConfig3 from '../viewconfigs/horizontal-multivec-4.json';
 
 
 import './App.scss';
+import { getAllViewAndTrackPairs } from '../utils/viewconf.js';
 
 const demos = {
     "Demo 1": {
@@ -27,7 +28,11 @@ const demos = {
             ],
             rowSort: [
                 {field: "Cell Type", type: "nominal", order: "ascending"}
-            ]
+            ],
+            rowFilter: [
+                {field: "Cell Type", type: "nominal", contains: "cell"}
+            ],
+            rowHighlight: {field: "Cell Type", type: "nominal", contains: "Stem"}
         }
     },
     "Demo 2": {

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -249,44 +249,6 @@ export function processWrapperOptions(optionsRaw) {
 }
 
 /**
- * Update a part of options, such as rowSort or rowHighlight.
- * @param {(object|object[]|null)} options The raw value of the options prop.
- * @param {object} subOption New sub-option to replace.
- * @param {string} key Key of the sub-option to replace in "options."
- * @param {boolean} isReplace Replace a suboption with new one or add to array
- * @returns {(object|object[])} The new options object or array.
- */
-export function updateGlobalOptionsWithKey(options, subOption, key, { isReplace }) {
-    let newOptions;
-
-    if(Array.isArray(options)){
-        let optionsRaw = options.slice();
-        let globalDefaults = optionsRaw.find(o => (o.viewId === DEFAULT_OPTIONS_KEY && o.trackId === DEFAULT_OPTIONS_KEY));
-        
-        // If there is no globar defaults, add one.
-        if(!globalDefaults) {
-            globalDefaults = {
-                viewId: DEFAULT_OPTIONS_KEY,
-                trackId: DEFAULT_OPTIONS_KEY
-            };
-            optionsRaw = insertItemToArray(optionsRaw, 0, globalDefaults);
-        }
-
-        const index = optionsRaw.indexOf(globalDefaults);
-        newOptions = modifyItemInArray(optionsRaw, index, {
-            ...globalDefaults,
-            [key]: isReplace ? subOption : insertItemToArray(globalDefaults[key], 0, subOption)
-        });
-    } else {
-        newOptions = {
-            ...options,
-            [key]: isReplace ? subOption : insertItemToArray(options[key], 0, subOption)
-        };
-    }
-    return newOptions;
-}
-
-/**
  * Get the options for a specific track, using its viewId and trackId.
  * @param {object} options A _processed_ options object.
  * @param {string} viewId The viewId for the track of interest.

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -179,6 +179,15 @@ export function validateWrapperOptions(optionsRaw) {
  * @returns {object} A processed options object, mapping track IDs to options objects, and merging with defaults.
  */
 export function processWrapperOptions(optionsRaw) {
+
+    // Important Descriptions about Wrapper Options (i.e., optionsRaw):
+    // * Single 'view' can contain multiple 'tracks,' but not vice versa.
+    // * Unlike HiGlass View Config, individual options for each combination of {viewId, trackId} are stored in an 1D array of JSON objects,
+    //   instead of using a nested format.
+    // * Both the viewId and trackId or only a viewId can be DEAULT_OPTIONS_KEY (i.e., only the trackId cannot be DEFAULT_OPTIONS_KEY).
+    // * Options of both viewId and trackId being DEFAULT_OPTIONS_KEY is a global option, which affects to any other tracks in any views.
+    // * Options of only a viewId being DEFAULT_OPTIONS_KEY is a track-global option, which affects to any tracks in a certain view.
+
     // Set up the default options:
     const options = {
         [DEFAULT_OPTIONS_KEY]: {
@@ -292,4 +301,8 @@ export function getTrackWrapperOptions(options, viewId, trackId) {
         }
     }
     return options[DEFAULT_OPTIONS_KEY];
+}
+
+export function updateWrapperOptions(options, newSubOptions, viewId, trackId) {
+    
 }

--- a/src/utils/options.spec.js
+++ b/src/utils/options.spec.js
@@ -2,8 +2,8 @@
 
 import { 
     validateWrapperOptions, 
-    processWrapperOptions, 
-    updateGlobalOptionsWithKey, 
+    processWrapperOptions,
+    updateWrapperOptions,
     getTrackWrapperOptions,
     DEFAULT_OPTIONS_KEY 
 } from './options.js';
@@ -128,37 +128,42 @@ describe('Utilities for processing wrapper component options', () => {
     });
 
     it('Should add sorting options to global default', () => {
-        const updatedOptions = updateGlobalOptionsWithKey([
+        const processedOptions = processWrapperOptions([
             {
-                viewId: "default",
-                trackId: "default",
+                viewId: DEFAULT_OPTIONS_KEY,
+                trackId: DEFAULT_OPTIONS_KEY,
                 colToolsPosition: "bottom"
             },
             {
                 viewId: "viewA",
-                trackId: "default",
+                trackId: DEFAULT_OPTIONS_KEY,
                 colToolsPosition: "top"
-            }],
+            }
+        ]);
+        const updatedOptions = updateWrapperOptions(
+            processedOptions,
             [{
                 field: "groupA",
                 type: "nominal",
                 order: "ascending"
             }],
             "rowSort",
+            DEFAULT_OPTIONS_KEY,
+            DEFAULT_OPTIONS_KEY,
             { isReplace: true }
         );
-        const globalDefaultOptions = updatedOptions.find(o => (o.viewId === DEFAULT_OPTIONS_KEY && o.trackId === DEFAULT_OPTIONS_KEY));
+        const globalDefaultOptions = updatedOptions[DEFAULT_OPTIONS_KEY];
         expect(globalDefaultOptions.rowSort.length).toBe(1);
         expect(globalDefaultOptions.rowSort[0].field).toBe("groupA");
         expect(globalDefaultOptions.rowSort[0].type).toBe("nominal");
         expect(globalDefaultOptions.rowSort[0].order).toBe("ascending");
     });
 
-    it('Should update sorting options to global default', () => {
-        const updatedOptions = updateGlobalOptionsWithKey([
+    it('Should update sorting options in global default', () => {
+        const processedOptions = processWrapperOptions([
             {
-                viewId: "default",
-                trackId: "default",
+                viewId: DEFAULT_OPTIONS_KEY,
+                trackId: DEFAULT_OPTIONS_KEY,
                 colToolsPosition: "bottom",
                 rowSort: [{
                     field: "groupB",
@@ -173,29 +178,34 @@ describe('Utilities for processing wrapper component options', () => {
             },
             {
                 viewId: "viewA",
-                trackId: "default",
+                trackId: DEFAULT_OPTIONS_KEY,
                 colToolsPosition: "top"
-            }],
+            }
+        ]);
+        const updatedOptions = updateWrapperOptions(
+            processedOptions,
             [{
                 field: "groupA",
                 type: "nominal",
                 order: "ascending"
             }],
             "rowSort",
+            DEFAULT_OPTIONS_KEY,
+            DEFAULT_OPTIONS_KEY,
             { isReplace: true }
         );
-        const globalDefaultOptions = updatedOptions.find(o => (o.viewId === DEFAULT_OPTIONS_KEY && o.trackId === DEFAULT_OPTIONS_KEY));
+        const globalDefaultOptions = updatedOptions[DEFAULT_OPTIONS_KEY];
         expect(globalDefaultOptions.rowSort.length).toBe(1);
         expect(globalDefaultOptions.rowSort[0].field).toBe("groupA");
         expect(globalDefaultOptions.rowSort[0].type).toBe("nominal");
         expect(globalDefaultOptions.rowSort[0].order).toBe("ascending");
     });
 
-    it('Should add filtering options in the list to global default', () => {
-        const updatedOptions = updateGlobalOptionsWithKey([
+    it('Should add filtering options in the list to track-global default', () => {
+        const processedOptions = processWrapperOptions([
             {
-                viewId: "default",
-                trackId: "default",
+                viewId: DEFAULT_OPTIONS_KEY,
+                trackId: DEFAULT_OPTIONS_KEY,
                 colToolsPosition: "bottom",
                 rowSort: [{
                     field: "groupA",
@@ -210,45 +220,55 @@ describe('Utilities for processing wrapper component options', () => {
             },
             {
                 viewId: "viewA",
-                trackId: "default",
+                trackId: DEFAULT_OPTIONS_KEY,
                 colToolsPosition: "top"
-            }],
+            }
+        ]);
+        const updatedOptions = updateWrapperOptions(
+            processedOptions,
             {
                 field: "groupC",
                 type: "nominal",
                 contains: "substringC"
             },
             "rowFilter",
+            "viewA",
+            DEFAULT_OPTIONS_KEY,
             { isReplace: false }
         );
-        const globalDefaultOptions = updatedOptions.find(o => (o.viewId === DEFAULT_OPTIONS_KEY && o.trackId === DEFAULT_OPTIONS_KEY));
-        expect(globalDefaultOptions.rowFilter.length).toBe(2);
-        expect(globalDefaultOptions.rowFilter.filter(d => d.field === "groupC").length).toBe(1);
-        expect(globalDefaultOptions.rowFilter.filter(d => d.type === "nominal").length).toBe(1);
-        expect(globalDefaultOptions.rowFilter.filter(d => d.contains === "substringC").length).toBe(1);
+        const trackGlobalOptions = updatedOptions["viewA"][DEFAULT_OPTIONS_KEY];
+        expect(trackGlobalOptions.rowFilter.length).toBe(2);
+        expect(trackGlobalOptions.rowFilter.filter(d => d.field === "groupC").length).toBe(1);
+        expect(trackGlobalOptions.rowFilter.filter(d => d.type === "nominal").length).toBe(1);
+        expect(trackGlobalOptions.rowFilter.filter(d => d.contains === "substringC").length).toBe(1);
     });
 
-    it('Should add global default options and add sorting info to the options', () => {
-        const updatedOptions = updateGlobalOptionsWithKey([
+    it('Should add sorting info to non-global options', () => {
+        const processedOptions = processWrapperOptions([
             {
                 viewId: "viewA",
-                trackId: "default",
+                trackId: "trackA",
                 colToolsPosition: "top"
-            }],
+            }
+        ]);
+        const updatedOptions = updateWrapperOptions(
+            processedOptions,
             [{
                 field: "groupA",
                 type: "nominal",
                 order: "ascending"
             }],
             "rowSort",
+            "viewA",
+            "trackA",
             { isReplace: true }
         );
-        const globalDefaultOptions = updatedOptions.find(o => (o.viewId === DEFAULT_OPTIONS_KEY && o.trackId === DEFAULT_OPTIONS_KEY));
-        expect(globalDefaultOptions !== undefined).toBe(true);
-        expect(globalDefaultOptions.rowSort.length).toBe(1);
-        expect(globalDefaultOptions.rowSort[0].field).toBe("groupA");
-        expect(globalDefaultOptions.rowSort[0].type).toBe("nominal");
-        expect(globalDefaultOptions.rowSort[0].order).toBe("ascending");
+        const nonGlobalOptions = updatedOptions["viewA"]["trackA"];
+        expect(nonGlobalOptions !== undefined).toBe(true);
+        expect(nonGlobalOptions.rowSort.length).toBe(1);
+        expect(nonGlobalOptions.rowSort[0].field).toBe("groupA");
+        expect(nonGlobalOptions.rowSort[0].type).toBe("nominal");
+        expect(nonGlobalOptions.rowSort[0].order).toBe("ascending");
     });
 
     it('Should return the processed options object for a particular track', () => {
@@ -277,6 +297,4 @@ describe('Utilities for processing wrapper component options', () => {
         }, "viewC", "trackA");
         expect(trackOptionsCA.colToolsPosition).toEqual("hidden");
     });
-
-
 });

--- a/src/utils/viewconf.js
+++ b/src/utils/viewconf.js
@@ -231,3 +231,27 @@ export function getHMSelectedRowsFromViewConfig(viewConfig, targetViewId, target
     });
     return selectedRows;
 }
+
+/**
+ * Get all view and track pairs.
+ * @param {object} viewConfig A valid higlass view config object.
+ * @returns {array} An array of objects of {traciId, viewId}.
+ */
+export function getAllViewAndTrackPairs(viewConfig) {
+    let pairs = [];
+    traverseViewConfig(viewConfig, (d) => {
+        // The horizontal-multivec track could be standalone, or within a "combined" track.
+        if(d.trackType === TRACK_TYPE.HORIZONTAL_MULTIVEC) {
+            pairs.push({
+                viewId: d.viewId,
+                trackId: d.trackId
+            });
+        } else if(d.trackType === TRACK_TYPE.COMBINED && d.innerTrackType === TRACK_TYPE.HORIZONTAL_MULTIVEC) {
+            pairs.push({
+                viewId: d.viewId,
+                trackId: d.innerTrackId
+            });
+        }
+    });
+    return pairs;
+}

--- a/src/utils/viewconf.spec.js
+++ b/src/utils/viewconf.spec.js
@@ -6,12 +6,14 @@ import {
     getSiblingVPHTrackIdsFromViewConfig,
     updateViewConfigOnSelectGenomicInterval,
     updateViewConfigOnSelectRowsByTrack,
-    getHMSelectedRowsFromViewConfig
+    getHMSelectedRowsFromViewConfig,
+    getAllViewAndTrackPairs
 } from './viewconf.js';
 
 import hgDemoViewConfig1 from '../viewconfigs/horizontal-multivec-1.json';
 import hgDemoViewConfig2 from '../viewconfigs/horizontal-multivec-2.json';
 import hgDemoViewConfig3 from '../viewconfigs/horizontal-multivec-3.json';
+import hgDemoViewConfig4 from '../viewconfigs/horizontal-multivec-4.json';
 import hgDemoViewConfig5 from '../viewconfigs/horizontal-multivec-5.json';
 
 describe('Utilities for processing higlass view config objects', () => {
@@ -62,5 +64,10 @@ describe('Utilities for processing higlass view config objects', () => {
         const selectedRows = getHMSelectedRowsFromViewConfig(hgDemoViewConfig5, "cistrome-view-5", "cistrome-track-5");
         expect(selectedRows).toEqual([5, 3, 1, 4]);
     });
-
+    
+    it('Should get viewId and trackId pairs of horizontal-multivec tracks', () => {
+        const searchedPairs = getAllViewAndTrackPairs(hgDemoViewConfig4);
+        expect(searchedPairs.length).toEqual(2);
+        expect(searchedPairs.find(d => d.viewId === "cistrome-view-4-1" && d.trackId === "cistrome-track-4-1") !== undefined).toEqual(true);
+    });
 });


### PR DESCRIPTION
I added [a callback function](https://github.com/hms-dbmi/cistrome-higlass-wrapper/blob/e4b9a80a0d4235f071e389841efe171d6074a24c/src/CistromeHGWConsumer.js#L61) to sort, filter, and highlight based on the initial wrapper options.

[Because rowInfo is loaded once a HiGlass is rendered](https://github.com/hms-dbmi/cistrome-higlass-wrapper/blob/e4b9a80a0d4235f071e389841efe171d6074a24c/src/TrackWrapper.js#L83), you can see that views are re-rendered at first for the initial sorting, filtering, and highlighting options. For this purpose, we may want to move this rowInfo part from `TrackWrapper.js` to `CistromeHGMConsumer.js`. What do you think about this?

I also cleaned up a little in the part of dealing with 'raw Options' and 'processed options'. Instead of updating `optionsRaw` and then generating `options` from the `optionsRow`, processed options (i.e., `setOptions`) are directly updated now: [link](https://github.com/hms-dbmi/cistrome-higlass-wrapper/blob/e4b9a80a0d4235f071e389841efe171d6074a24c/src/utils/options.js#L279).

I added an indicator for the highlighting status in each vertical track.

Fixes #78 