### PR TITLE
Minor changes to pull request 121

### DIFF
--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -51,13 +51,13 @@ export default function CistromeHGWConsumer(props) {
     const hgRef = useRef();
     const drawRef = useRef({});
 
-    const [options, setOptions] = useState(processWrapperOptions(optionsRaw));
+    const [options, setOptions] = useState({});
     const [trackInfos, setTrackInfos] = useState([]);
     const [siblingTrackInfos, setSiblingTrackInfos] = useState({});
     
     const context = useContext(InfoContext);
 
-    // Set initial sorting, filtering, and highlighting
+    // Set initial sorting, filtering, and highlighting.
     const onMetadataLoad = useCallback((viewId, trackId) => {
         const trackOptions = getTrackWrapperOptions(options, viewId, trackId);
         const rowInfo = context.state[viewId][trackId].rowInfo;
@@ -72,7 +72,7 @@ export default function CistromeHGWConsumer(props) {
             const newHighlitRows = highlightRowsFromSearch(rowInfo, field, type, contains);
             setHighlitRows(viewId, trackId, newHighlitRows);
         }
-    });
+    }, [options]);
 
     /*
      * Function to call when the view config has changed.
@@ -99,8 +99,6 @@ export default function CistromeHGWConsumer(props) {
                     selectedRows: newSelectedRows
                 });
             }
-
-            // TODO: dispatch for highlighting
         }
         setTrackInfos(newTrackInfos);
         setSiblingTrackInfos(newSiblingTrackInfos);
@@ -113,7 +111,7 @@ export default function CistromeHGWConsumer(props) {
         } catch(e) {
             return null;
         }
-    }, []);
+    }, [hgRef]);
 
     const setTrackSelectedRows = useCallback((viewId, trackId, selectedRows) => {
         const currViewConfig = hgRef.current.api.getViewConfig();
@@ -130,7 +128,7 @@ export default function CistromeHGWConsumer(props) {
             trackId,
             highlitRows
         });
-    });
+    }, [hgRef]);
 
     // Function for child components to call to "register" their draw functions.
     const drawRegister = useCallback((key, drawFunction) => {
@@ -147,7 +145,7 @@ export default function CistromeHGWConsumer(props) {
 
         setTrackSelectedRows(viewId, trackId, newSelectedRows);
         setOptions(newOptions);
-    });
+    }, [options]);
 
     // Callback function for searching and highlighting.
     const onSearchRows = useCallback((viewId, trackId, field, type, contains) => {
@@ -160,7 +158,7 @@ export default function CistromeHGWConsumer(props) {
         const newHighlitRows = highlightRowsFromSearch(context.state[viewId][trackId].rowInfo, field, type, contains);
         setHighlitRows(viewId, trackId, newHighlitRows);
         setOptions(newOptions);
-    });
+    }, [options]);
 
     // Callback function for filtering.
     const onFilterRows = useCallback((viewId, trackId, field, type, contains) => {
@@ -175,7 +173,7 @@ export default function CistromeHGWConsumer(props) {
         setHighlitRows(viewId, trackId, undefined);
         setTrackSelectedRows(viewId, trackId, newSelectedRows);
         setOptions(newOptions);
-    });
+    }, [options]);
 
     // Do initial processing of the options prop.
     useEffect(() => {

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -1,5 +1,4 @@
-import React, { useContext } from 'react';
-import range from 'lodash/range';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { InfoContext, ACTION } from "./utils/contexts.js";
 import TrackColTools from './TrackColTools.js';
@@ -45,6 +44,14 @@ export default function TrackWrapper(props) {
 
     const context = useContext(InfoContext);
 
+    const [shouldCallOnMetadataLoad, setShouldCallOnMetadataLoad] = useState(false);
+
+    useEffect(() => {
+        if(shouldCallOnMetadataLoad) {
+            onMetadataLoad();
+        }
+    }, [shouldCallOnMetadataLoad, multivecTrackViewId, multivecTrackTrackId]);
+
     if(!multivecTrack || !multivecTrack.tilesetInfo || !multivecTrack.tilesetInfo.shape) {
         // The track or track tileset info has not yet loaded.
         return null;
@@ -80,7 +87,7 @@ export default function TrackWrapper(props) {
                 trackId: multivecTrackTrackId,
                 rowInfo: rowInfo
             });
-            onMetadataLoad();
+            setShouldCallOnMetadataLoad(true);
         }
     } catch(e) {
         console.log(e);

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -8,7 +8,6 @@ import hgDemoViewConfig3 from '../viewconfigs/horizontal-multivec-4.json';
 
 
 import './App.scss';
-import { getAllViewAndTrackPairs } from '../utils/viewconf.js';
 
 const demos = {
     "Demo 1": {


### PR DESCRIPTION
This is a pull request into your pull request branch.

I was seeing this warning, so I think the `onMetadataLoad` should be called in a `useEffect` rather than directly in the render function.

https://github.com/hms-dbmi/cistrome-higlass-wrapper/compare/sehilyi/fix-78...keller-mark/fix-78-update?expand=1#diff-adae11a6acfedf9f91b7f703a7c80679R50


I also removed the processWrapperOptions call from the `useState()` call, since the wrapper options only need to be processed when the `optionsRaw` changes https://github.com/hms-dbmi/cistrome-higlass-wrapper/compare/sehilyi/fix-78...keller-mark/fix-78-update?expand=1#diff-1a84645fc8258869422733acd3c33673R180

https://github.com/hms-dbmi/cistrome-higlass-wrapper/compare/sehilyi/fix-78...keller-mark/fix-78-update?expand=1#diff-1a84645fc8258869422733acd3c33673L54

I also tried to clean up the effect and callback dependency arrays.