### PR TITLE
Minor update on text height measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Changed rollup config `output.sourcemap` values to `true` rather than `"inline"`, which means that sourcemaps are stored in separate files, reducing the size of the `.js` files.
 - Updated the positioning of the genomic interval start and end coordinate elements, so that they are dynamically positioned based on the current genomic region in the track.
 - Added a small implementation of renderer-agnostic drawing code, based on the `two.js` JavaScript library, which enables the same code to draw to SVG and canvas elements. For example, when rendering in the browser, canvas is preferred for speed, but when rendering for export to a file, SVG is preferred for resolution.
+- Fixed bug which prevented wrapper options for sorting, filtering, highlighting from being used upon initial component render.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@
 - Added a feature to interactively filter rows by keywords and reset all filters.
 - Added an option to specify multiple data fields in a single vertical track and implemented stacked bar charts for this case.
 - Added a feature to interactively filter rows by selecting a node in the dendrogram visualization.
-- Add x-axis ticks for quantitative bar plot visualizations for row info metadata.
-- Add transparent white background for visualization title text so that it does not visually interfere with the text for plot data labels.
+- Added x-axis ticks for quantitative bar plot visualizations for row info metadata.
+- Added transparent white background for visualization title text so that it does not visually interfere with the text for plot data labels.
+- Added `measureText()` two function for computing width and height of `TwoText` objects without rendering.
 
 ### Changed
 - Moved to rendering the row info categorical metadata on a single `<canvas/>` element, rather than colored HTML elements for each row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Added a feature to interactively filter rows by keywords and reset all filters.
 - Added an option to specify multiple data fields in a single vertical track and implemented stacked bar charts for this case.
 - Added a feature to interactively filter rows by selecting a node in the dendrogram visualization.
+- Add x-axis ticks for quantitative bar plot visualizations for row info metadata.
+- Add transparent white background for visualization title text so that it does not visually interfere with the text for plot data labels.
 
 ### Changed
 - Moved to rendering the row info categorical metadata on a single `<canvas/>` element, rather than colored HTML elements for each row.

--- a/src/CistromeHGWConsumer.js
+++ b/src/CistromeHGWConsumer.js
@@ -59,6 +59,9 @@ export default function CistromeHGWConsumer(props) {
 
     // Set initial sorting, filtering, and highlighting.
     const onMetadataLoad = useCallback((viewId, trackId) => {
+        if(!context.state[viewId] || !context.state[viewId][trackId]) {
+            return;
+        }
         const trackOptions = getTrackWrapperOptions(options, viewId, trackId);
         const rowInfo = context.state[viewId][trackId].rowInfo;
         

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -122,7 +122,7 @@ export default function TrackRowInfoVisDendrogram(props) {
             rect.opacity = 0.8;
         }
 
-        drawVisTitle(field, { two, isLeft, isNominal, width });
+        drawVisTitle(field, { two, isLeft, width, height });
 
         const points = descendants.map(pointFromNode);
         const delaunay = d3.delaunay.from(points);

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -22,8 +22,6 @@ const margin = 5;
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
- * @prop {string} viewId The viewId for the horizontal-multivec track.
- * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} onFilterRows The function to call upon a filter interaction.
@@ -31,7 +29,6 @@ const margin = 5;
  */
 export default function TrackRowInfoVisLink(props) {
     const {
-        viewId, trackId,
         left, top, width, height,
         fieldInfo,
         isLeft,
@@ -69,25 +66,23 @@ export default function TrackRowInfoVisLink(props) {
             domElement
         });
 
-        drawVisTitle(field, { two, isLeft, isNominal, width, titleSuffix });
-
-        if(rowHeight < fontSize) {
-            // Bail out if there is not enough height per row to render links.
-            return two.teardown;
+        if(rowHeight >= fontSize) {
+            // There is enough height to render the text elements.
+            transformedRowInfo.forEach((info, i) => {
+                const textTop = yScale(i);
+                const textLeft = isLeft ? width - margin : margin;
+                const titleField = title ? title : field;
+                const diplayText = isTextLabel ? info[titleField] : "Link";
+                const text = two.makeText(textLeft, textTop + rowHeight/2, width, rowHeight, diplayText);
+                text.fill = "#23527C";
+                text.fontsize = fontSize;
+                text.align = textAlign;
+                text.baseline = "middle";
+                text.overflow = "ellipsis";
+            });
         }
 
-        transformedRowInfo.forEach((info, i) => {
-            const textTop = yScale(i);
-            const textLeft = isLeft ? width - margin : margin;
-            const titleField = title ? title : field;
-            const diplayText = isTextLabel ? info[titleField] : "Link";
-            const text = two.makeText(textLeft, textTop + rowHeight/2, width, rowHeight, diplayText);
-            text.fill = "#23527C";
-            text.fontsize = fontSize;
-            text.align = textAlign;
-            text.baseline = "middle";
-            text.overflow = "ellipsis";
-        });
+        drawVisTitle(field, { two, isLeft, width, height, titleSuffix });
         
         two.update();
         return two.teardown;

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -23,8 +23,6 @@ export const margin = 5;
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
- * @prop {string} viewId The viewId for the horizontal-multivec track.
- * @prop {string} trackId The trackId for the horizontal-multivec track.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} onFilterRows The function to call upon a filter interaction.
@@ -35,8 +33,6 @@ export default function TrackRowInfoVisNominalBar(props) {
         left, top, width, height,
         fieldInfo,
         isLeft,
-        viewId,
-        trackId,
         transformedRowInfo,
         titleSuffix,
         onSortRows,
@@ -68,8 +64,7 @@ export default function TrackRowInfoVisNominalBar(props) {
         });
 
         const titleText = Array.isArray(field) ? field.join(" + ") : field;
-        drawVisTitle(titleText, { two, isLeft, isNominal: true, width, titleSuffix });
-
+        
         const textAreaWidth = width - 20;
         const barAreaWidth = width - textAreaWidth;
         const minTrackWidth = 40;
@@ -77,11 +72,7 @@ export default function TrackRowInfoVisNominalBar(props) {
         const fontSize = 10;
         
         // Scales
-        const valueExtent = [0, d3.extent(transformedRowInfo.map(d => d[field]))[1]];   // Zero baseline
-       
-        const xScale = d3.scaleLinear()
-            .domain(valueExtent)
-            .range([0, barAreaWidth]);    
+
 
         // Render visual components for each row (i.e., bars and texts).
         const textAlign = isLeft ? "end" : "start";
@@ -120,6 +111,8 @@ export default function TrackRowInfoVisNominalBar(props) {
             aggregateStartIdx = -1;
             sameCategoriesNearby = 1;
         });
+
+        drawVisTitle(titleText, { two, isLeft, width, height, titleSuffix });
 
         two.update();
         return two.teardown;

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -70,9 +70,6 @@ export default function TrackRowInfoVisNominalBar(props) {
         const minTrackWidth = 40;
         const isTextLabel = width > minTrackWidth;
         const fontSize = 10;
-        
-        // Scales
-
 
         // Render visual components for each row (i.e., bars and texts).
         const textAlign = isLeft ? "end" : "start";

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -91,7 +91,6 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
         });
 
         const titleText = isStackedBar ? field.join(" + ") : field;
-        drawVisTitle(titleText, { two, isLeft, isNominal: false, width, titleSuffix });
 
         const isTextLabel = width > minTrackWidth;
        
@@ -192,6 +191,8 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             });
         }
 
+        drawVisTitle(titleText, { two, isLeft, width, height, titleSuffix });
+
         two.update();
         return two.teardown;
     });
@@ -265,6 +266,7 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
             teardown();
             teardownHidden();
             teardownSvg();
+            d3.select(div).on("mouseenter", null);
             d3.select(div).on("mouseleave", null);
         };
     }, [top, left, width, height, transformedRowInfo]);

--- a/src/utils/two.js
+++ b/src/utils/two.js
@@ -599,13 +599,9 @@ export default class Two {
 
         // Measure the dimensions.
         const dims = { width: 0, height: 0 };
-        try {
-            const metrics = context.measureText(content);
-            dims.width = metrics.width;
-            dims.height = (metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent);
-        } catch(e) {
-            console.log(e);
-        }
+        dims.width = context.measureText(content).width;
+        // Approximation of text height (https://stackoverflow.com/a/13318387).
+        dims.height = context.measureText("M").width;
         
         if(d.rotation !== null) {
             context.restore();
@@ -613,8 +609,6 @@ export default class Two {
 
         return dims;
     }
-
-    
 
     /**
      * Clean up the DOM element (remove event listeners, etc.).

--- a/src/utils/two.js
+++ b/src/utils/two.js
@@ -271,7 +271,7 @@ export default class Two {
      * @param {number} height The height for the text.
      * @returns {TwoText} Instance of new text.
      */
-    makeText(x, y, width, height, text, withRect = false) {
+    makeText(x, y, width, height, text) {
         const obj = new TwoText(x, y, width, height, text);
         this.elements.push(obj);
         return obj;

--- a/src/utils/two.js
+++ b/src/utils/two.js
@@ -8,7 +8,7 @@ import { getRetinaRatio } from './canvas.js';
  * @param {number} width
  * @param {number} height
  */
-class TwoRectangle {
+export class TwoRectangle {
     constructor(x, y, width, height) {
         this.x = x;
         this.y = y;
@@ -36,7 +36,7 @@ class TwoRectangle {
  * @param {number} y
  * @param {number} radius
  */
-class TwoCircle {
+export class TwoCircle {
     constructor(x, y, radius) {
         this.x = x;
         this.y = y;
@@ -61,7 +61,7 @@ class TwoCircle {
  * @param {number} x2
  * @param {number} y2
  */
-class TwoLine {
+export class TwoLine {
     constructor(x1, y1, x2, y2) {
         this.x1 = x1;
         this.y1 = y1;
@@ -82,7 +82,7 @@ class TwoLine {
  * Represents a path to be rendered.
  * @param {number[]} points
  */
-class TwoPath {
+export class TwoPath {
     constructor(points) {
         this.points = points;
 
@@ -104,7 +104,7 @@ class TwoPath {
  * @param {number} height
  * @param {string} text
  */
-class TwoText {
+export class TwoText {
     constructor(x, y, width, height, text) {
         this.x = x;
         this.y = y;
@@ -136,6 +136,8 @@ class TwoText {
          * @member {string} */
         this.overflow = null;
     }
+
+
 }
 
 /**
@@ -164,11 +166,13 @@ export default class Two {
                 this.init = this.initCanvas.bind(this);
                 this.update = this.updateCanvas.bind(this);
                 this.teardown = this.teardownCanvas.bind(this);
+                this.measureText = this.measureTextCanvas.bind(this);
                 break;
             case 'svg':
                 this.init = this.initSvg.bind(this);
                 this.update = this.updateSvg.bind(this);
                 this.teardown = this.teardownSvg.bind(this);
+                this.measureText = this.measureTextSvg.bind(this);
                 break;
             default:
                 console.warn("Unknown DOM element type.");
@@ -267,10 +271,18 @@ export default class Two {
      * @param {number} height The height for the text.
      * @returns {TwoText} Instance of new text.
      */
-    makeText(x, y, width, height, text) {
+    makeText(x, y, width, height, text, withRect = false) {
         const obj = new TwoText(x, y, width, height, text);
         this.elements.push(obj);
         return obj;
+    }
+
+    /**
+     * Append a TwoText, TwoCircle, TwoRect, TwoPath, etc. to the current list of shape elements.
+     * @param {*} obj 
+     */
+    append(obj) {
+        this.elements.push(obj);
     }
 
     /**
@@ -498,6 +510,111 @@ export default class Two {
             }
         });
     }
+
+    /**
+     * Compute width and height for a particular text element.
+     * @param {TwoText} d The object representing the text to be measured.
+     * @returns {object} Object containing the values `width` and `height`.
+     */
+    measureText(d) {
+        return { width: 0, height: 0 };
+    }
+
+    measureTextSvg(d) {
+        const svg = d3.create("svg");
+        const g = svg.append("g");
+
+        const text = g.append("text")
+            .attr("x", d.x)
+            .attr("y", d.y)
+            .attr("text-anchor", d.align)
+            .attr("dominant-baseline", 
+                (d.baseline === "top" ? "text-before-edge" : (d.baseline === "bottom" ? "text-after-edge" : d.baseline))
+            )
+            .attr("opacity", d.opacity)
+            .attr("fill", d.fill)
+            .attr("font-size", d.fontsize)
+            .attr("font-family", d.font)
+            .text(d.text);
+        
+        let content = d.text;
+        if(d.overflow === "clip") {
+            while(content.length > 0 && text.node().getComputedTextLength() > d.width) {
+                content = content.substring(0, content.length - 1);
+                text.text("content");
+            }
+        } else if(d.overflow === "ellipsis") {
+            if(text.node().getComputedTextLength() > d.width) {
+                while(content.length > 0 && text.node().getComputedTextLength() > d.width) {
+                    content = content.substring(0, content.length - 1);
+                    text.text(content + "...");
+                }
+            }
+        }
+        
+        if(d.rotation != null) {
+            text
+                .attr("transform", `rotate(${d.rotation * 180/Math.PI},${d.x},${d.y})`);
+        }
+
+        // Measure the dimensions.
+        const dims = { width: 0, height: 0 };
+        try {
+            const { width, height } = text.node().getBBox();
+            dims.width = width;
+            dims.height = height;
+        } catch(e) {
+            console.log(e);
+        }
+
+        return dims;
+    }
+
+    measureTextCanvas(d) {
+        const context = this.context;
+        if(d.rotation !== null) {
+            context.save();
+            context.translate(d.x, d.y);
+            context.rotate(d.rotation);
+            context.translate(-d.x, -d.y);
+        }
+        context.font = `${d.fontsize}px ${d.font}`;
+        context.fillStyle = d.fill;
+        context.textAlign = (d.align === "middle" ? "center" : d.align);
+        context.textBaseline = d.baseline;
+
+        let content = d.text;
+        if(d.overflow === "clip") {
+            while(content.length > 0 && context.measureText(content).width > d.width) {
+                content = content.substring(0, content.length - 1);
+            }
+        } else if(d.overflow === "ellipsis") {
+            if(context.measureText(content).width > d.width) {
+                while(content.length > 0 && context.measureText(content + "...").width > d.width) {
+                    content = content.substring(0, content.length - 1);
+                }
+                content = content + "...";
+            }
+        }
+
+        // Measure the dimensions.
+        const dims = { width: 0, height: 0 };
+        try {
+            const metrics = context.measureText(content);
+            dims.width = metrics.width;
+            dims.height = (metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent);
+        } catch(e) {
+            console.log(e);
+        }
+        
+        if(d.rotation !== null) {
+            context.restore();
+        }
+
+        return dims;
+    }
+
+    
 
     /**
      * Clean up the DOM element (remove event listeners, etc.).

--- a/src/utils/vis.js
+++ b/src/utils/vis.js
@@ -1,4 +1,4 @@
-
+import { TwoText, TwoRectangle } from "./two.js";
 
 /**
  * Common function for rendering the title text for a vertical visualization component.
@@ -6,24 +6,45 @@
  * @param {object} options Options for drawing title.
  * @param {Two} options.two The object of Two.js class.
  * @param {boolean} options.isLeft In this view placed on the left side of the track?
- * @param {boolean} options.isNominal Is this view visualizes a nominal value?
  * @param {number} options.width Width of this view.
- * @param {string} options.titleSuffix The suffix of a title, information about sorting and filtering status.
+ * @param {string} options.titleSuffix The suffix of a title, information about sorting and filtering status. Optional.
+ * @param {string} options.backgroundColor If defined, creates a rect behind the text element. Optional. By default, "#FFF".
  */
 export function drawVisTitle(text, options) {
-    const { two, isLeft, isNominal, width, titleSuffix } = options;
+    const {
+        two,
+        isLeft,
+        width,
+        height,
+        titleSuffix = "",
+        backgroundColor = "white"
+    } = options;
     
-    const margin = 5;
-    const barAreaWidth = isNominal ? 20 : width - 20;
+    const margin = 4;
     const titleFontSize = 12;
-    const titleLeft = (isLeft ? margin : width - margin);
+    const titleLeftInitial = isLeft ? margin : (width - margin);
     const titleRotate = isLeft ? -Math.PI/2 : Math.PI/2;
-    const fullText = text + (titleSuffix ? titleSuffix : "");
+    const fullText = `${text}${titleSuffix}`;
 
-    const title = two.makeText(titleLeft, 0, 12, barAreaWidth, fullText);
+    const title = new TwoText(titleLeftInitial, 0, width, height, fullText);
     title.fill = "#9A9A9A";
     title.fontsize = titleFontSize;
     title.align = isLeft ? "end" : "start";
-    title.baseline = "top";
+    title.baseline = isLeft ? "top" : "bottom";
     title.rotation = titleRotate;
+
+    const titleDims = two.measureText(title);
+    const titleLeft = isLeft ? titleLeftInitial : titleLeftInitial - titleDims.height;
+    title.x = titleLeft;
+
+    if(backgroundColor) {
+        const rect = new TwoRectangle(titleLeft - margin, 0, titleDims.height + 2*margin, titleDims.width);
+        rect.fill = backgroundColor;
+        rect.stroke = null;
+        rect.opacity = 0.8;
+
+        two.append(rect);
+    }
+
+    two.append(title);
 }

--- a/src/utils/vis.js
+++ b/src/utils/vis.js
@@ -38,7 +38,7 @@ export function drawVisTitle(text, options) {
     title.x = titleLeft;
 
     if(backgroundColor) {
-        const rect = new TwoRectangle(titleLeft - margin, 0, titleDims.height + 2*margin, titleDims.width);
+        const rect = new TwoRectangle(titleLeft - margin, 0, 10 + 2*margin, titleDims.width);
         rect.fill = backgroundColor;
         rect.stroke = null;
         rect.opacity = 0.8;

--- a/src/utils/vis.js
+++ b/src/utils/vis.js
@@ -38,7 +38,7 @@ export function drawVisTitle(text, options) {
     title.x = titleLeft;
 
     if(backgroundColor) {
-        const rect = new TwoRectangle(titleLeft - margin, 0, 10 + 2*margin, titleDims.width);
+        const rect = new TwoRectangle(titleLeft - 2, 0, titleDims.height + 6, titleDims.width);
         rect.fill = backgroundColor;
         rect.stroke = null;
         rect.opacity = 0.8;


### PR DESCRIPTION
It looks FireFox and IE do not support `actualBoundingBoxAscent` and  `actualBoundingBoxDescent`, making titles or backgrounds not to be rendered (https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics).

![Screen Shot 2020-02-26 at 10 54 19 AM](https://user-images.githubusercontent.com/9922882/75365290-ffe2b480-588a-11ea-9efb-b3d6d8114e44.png)
![Screen Shot 2020-02-26 at 10 54 23 AM](https://user-images.githubusercontent.com/9922882/75365292-ffe2b480-588a-11ea-9fca-34a7f561d594.png)


I changed the text height measurement for canvas:
https://github.com/hms-dbmi/cistrome-higlass-wrapper/blob/e1af89e050f0098f14e8d94ae771551c9ca3f6fb/src/utils/two.js#L603-L604