### PR TITLE
Minor changes in keyword suggestions

### DIFF
--- a/src/TrackRowSearch.js
+++ b/src/TrackRowSearch.js
@@ -3,7 +3,7 @@ import { CLOSE, FILTER, UNDO } from './utils/icons.js';
 
 import './TrackRowSearch.scss';
 
-const MAX_NUM_SUGGESTIONS = 40;
+const MAX_NUM_SUGGESTIONS = 15;
 
 /**
  * Returns <span> elements in which text is highlighted based on a keyword
@@ -22,11 +22,16 @@ function SuggestionWithHighlight(props) {
     const s1 = text.substring(i0, i1);
     const s2 = text.substring(i1, text.length);
     return (
-        <span>
-            <span>{s0}</span>
-            <span style={{backgroundColor: 'yellow'}}>{s1}</span>
-            <span>{s2}</span>
-        </span>
+        <div 
+            style={{ display: "flex", alignItems: "center" }}>
+            <svg className="chgw-button-sm chgw-search-button chgw-button-static"
+                viewBox={FILTER.viewBox}>
+                <path d={FILTER.path} fill="gray"/>
+            </svg>
+            <span>
+                {s0}<b>{s1}</b>{s2}
+            </span>
+        </div>
     );
 }
 
@@ -74,6 +79,8 @@ export default function TrackRowSearch(props) {
                 const potentialResult = Array.from(new Set(fieldDataByKeyword));
                 if(potentialResult.length < MAX_NUM_SUGGESTIONS) {
                     result = potentialResult;
+                } else {
+                    result = potentialResult.slice(0, MAX_NUM_SUGGESTIONS);
                 }
             }
             // Sort so that suggestions that _start with_ the keyword appear first.

--- a/src/TrackRowSearch.scss
+++ b/src/TrackRowSearch.scss
@@ -20,6 +20,7 @@
         line-height: 14px;
         border-left: 1px solid silver;
         border-right: 1px solid silver;
+        border-bottom: 1px solid silver;
         position: absolute;
         background: white;
         ul {
@@ -27,23 +28,24 @@
             padding: 0;
             margin-bottom: 0;
             li {
-                border-bottom: 1px solid silver;
-                padding: 2px;
+                padding: 6px 6px 6px 0;
             }
         }
     }
 }
 
 .chgw-search-button {
-    margin: 0 auto;
-    display: block;
+    margin: 0;
+}
+
+.chgw-button-static {
+    pointer-events: none;
 }
 
 .chgw-search-suggestion-text {
     cursor: pointer;
-    color: silver;
 }
 
 .chgw-search-suggestion-text.active-suggestion {
-    color: dimgray;
+    background: rgb(225, 225, 225);
 }


### PR DESCRIPTION
- Added filter icons in front of each suggestion to explicitly show that clicking on a keyword directly filter rows.
- Changed styles a bit, mainly in order to more clearly show suggestions (gray -> black) and to show the matching keywords less visually salient (yellow bg -> bold font).
- Showed top N suggestions even if the size of potential results are larger than predefined N.

![image](https://user-images.githubusercontent.com/9922882/75570825-f6418400-5a25-11ea-854d-604008c8ff16.png)
