### PR TITLE
Add top track position demo

### DIFF
--- a/src/TrackColSelectionInfo.js
+++ b/src/TrackColSelectionInfo.js
@@ -167,6 +167,7 @@ export default function TrackColSelectionInfo(props) {
                 {(!chrStartName || !chrStartPos || !chrEndName || !chrEndPos) ? null : (
                     dbToolkitURL ? (
                         <a 
+                            className="col-tools-target"
                             href={dbToolkitURL}
                             target="_blank"
                         >

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -54,16 +54,17 @@ export default function TrackColTools(props) {
                 top: `${top}px`,
                 left: `${left}px`, 
                 width: `${width}px`,
-                height: `${height}px`
+                height: `${height}px`,
+                pointerEvents: 'none'
             }}
         >
             <div className="col-tools">
                 {!combinedTrack ? (
                     <button 
+                        className="col-tools-target"
                         onClick={onSelectGenomicInterval}
                         style={{
-                            position: 'absolute',
-                            top: (isTop ? (2*height/3) : 2),
+                            marginTop: (isTop ? (2*height/3) : 2)
                         }}
                     >Select current interval</button>
                 ) : (

--- a/src/TrackColTools.scss
+++ b/src/TrackColTools.scss
@@ -5,4 +5,9 @@
     height: 100%;
     width: 100%;
     text-align: center;
+    pointer-events: none;
+}
+
+.col-tools-target {
+    pointer-events: auto;
 }

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -67,9 +67,6 @@ export default function TrackWrapper(props) {
     const trackHeight = multivecTrack.dimensions[1];
     const totalNumRows = multivecTrack.tilesetInfo.shape[1];
 
-    console.log(trackHeight);
-    console.log(multivecTrack);
-
     // Attempt to obtain metadata values from the `tilesetInfo` field of the track.
     let rowInfo = [];
     let trackAssembly = null;

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -67,6 +67,9 @@ export default function TrackWrapper(props) {
     const trackHeight = multivecTrack.dimensions[1];
     const totalNumRows = multivecTrack.tilesetInfo.shape[1];
 
+    console.log(trackHeight);
+    console.log(multivecTrack);
+
     // Attempt to obtain metadata values from the `tilesetInfo` field of the track.
     let rowInfo = [];
     let trackAssembly = null;

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -4,11 +4,12 @@ import { CistromeHGW } from '../index.js';
 
 import hgDemoViewConfig1 from '../viewconfigs/horizontal-multivec-1.json';
 import hgDemoViewConfig6 from '../viewconfigs/horizontal-multivec-6.json';
+import hgDemoViewConfig7 from '../viewconfigs/horizontal-multivec-7.json';
 
 import './App.scss';
 
 const demos = {
-    "H3K27ac Demo (Single View)": {
+    "H3K27ac Demo (1 View, Center Track)": {
         viewConfig: hgDemoViewConfig1,
         options: {
             colToolsPosition: "bottom",
@@ -29,7 +30,7 @@ const demos = {
             rowHighlight: {field: "Cell Type", type: "nominal", contains: "Stem"}
         }
     },
-    "H3K27ac Demo (Multiple Views)": {
+    "H3K27ac Demo (2 Views, Center Tracks)": {
         viewConfig: hgDemoViewConfig6,
         options: [
             {
@@ -58,7 +59,28 @@ const demos = {
                 ]
             }
         ]
-    }
+    },
+    "H3K27ac Demo (1 View, Top Track)": {
+        viewConfig: hgDemoViewConfig7,
+        options: {
+            colToolsPosition: "bottom",
+            rowInfoAttributes: [
+                {field: "Hierarchical Clustering (Average)", type: "tree", position: "left"},
+                {field: "Random 3", type: "quantitative", position: "left"},
+                {field: ["Random 1", "Random 2", "Random 3", "Random 4"], type: "quantitative", position: "left"},
+                {field: "Metadata URL", type: "url", position: "left", title: "cid"},
+                {field: "Hierarchical Clustering (Ward)", type: "tree", position: "right"},
+                {field: "Cell Type", type: "nominal", position: "right"},
+                {field: "Tissue Type", type: "nominal", position: "right"},
+                {field: "Species", type: "nominal", position: "right"}
+            ],
+            rowSort: [
+                {field: "Cell Type", type: "nominal", order: "ascending"}
+            ],
+            rowFilter: [],
+            rowHighlight: {field: "Cell Type", type: "nominal", contains: "Stem"}
+        }
+    },
 };
 
 function onViewConfigChange(viewConfigString) {

--- a/src/demo/fakedata/index.js
+++ b/src/demo/fakedata/index.js
@@ -36,4 +36,9 @@ export default {
             rowInfo: rowInfo1
         }
     },
+    "cistrome-track-7": {
+        tilesetInfo: {
+            rowInfo: rowInfo1
+        }
+    },
 };

--- a/src/viewconfigs/horizontal-multivec-7.json
+++ b/src/viewconfigs/horizontal-multivec-7.json
@@ -1,0 +1,204 @@
+{
+    "editable": true,
+    "zoomFixed": false,
+    "trackSourceServers": [
+      "https://higlass.io/api/v1"
+    ],
+    "exportViewUrl": "/api/v1/viewconfs",
+    "views": [
+      {
+        "initialXDomain": [
+          226426442.00375226,
+          226667818.0304663
+        ],
+        "initialYDomain": [
+          2671196920.8697634,
+          2671320441.9350777
+        ],
+        "tracks": {
+          "top": [
+            {
+              "type": "horizontal-chromosome-labels",
+              "uid": "GzHGPlijS2eASBqslzVcxA",
+              "tilesetUid": "ZpZ8c5JJRUS1J7ZkofcUrg",
+              "server": "https://resgen.io/api/v1",
+              "options": {
+                "showMousePosition": false,
+                "mousePositionColor": "#999999",
+                "color": "#808080",
+                "stroke": "#ffffff",
+                "fontSize": 12,
+                "fontIsLeftAligned": false
+              },
+              "width": 1027,
+              "height": 30
+            },
+            {
+              "type": "horizontal-bar",
+              "uid": "bmcNxj_MSEar_3nYVMnPnQ",
+              "tilesetUid": "a-iBpdh3Q_uO2FLCWKpOOw",
+              "server": "https://resgen.io/api/v1",
+              "options": {
+                "labelColor": "black",
+                "labelPosition": "topLeft",
+                "axisPositionHorizontal": "right",
+                "barFillColor": "darkgreen",
+                "valueScaling": "linear",
+                "trackBorderWidth": 0,
+                "trackBorderColor": "black",
+                "labelTextOpacity": 0.4,
+                "barOpacity": 1,
+                "name": "conservation (hg38.phastCons100way.bw)",
+                "align": "bottom",
+                "labelLeftMargin": 0,
+                "labelRightMargin": 0,
+                "labelTopMargin": 0,
+                "labelBottomMargin": 0,
+                "labelShowResolution": false,
+                "axisLabelFormatting": "scientific"
+              },
+              "width": 568,
+              "height": 42,
+              "aggregationModes": {
+                "mean": {
+                  "name": "Mean",
+                  "value": "mean"
+                },
+                "min": {
+                  "name": "Min",
+                  "value": "min"
+                },
+                "max": {
+                  "name": "Max",
+                  "value": "max"
+                },
+                "std": {
+                  "name": "Standard Deviation",
+                  "value": "std"
+                }
+              }
+            },
+            {
+              "type": "horizontal-stacked-bar",
+              "uid": "dEHMyN28RFSG1f-cPS6V2w",
+              "tilesetUid": "HMSJyvLCSgGmrDJctdIz3w",
+              "server": "https://resgen.io/api/v1",
+              "options": {
+                "labelPosition": "topLeft",
+                "labelColor": "black",
+                "labelTextOpacity": 0.4,
+                "valueScaling": "exponential",
+                "trackBorderWidth": 0,
+                "trackBorderColor": "black",
+                "backgroundColor": "white",
+                "barBorder": false,
+                "scaledHeight": false,
+                "sortLargestOnTop": true,
+                "colorScale": [
+                  "#FF0000",
+                  "#FF4500",
+                  "#32CD32",
+                  "#008000",
+                  "#006400",
+                  "#C2E105",
+                  "#FFFF00",
+                  "#66CDAA",
+                  "#8A91D0",
+                  "#CD5C5C",
+                  "#E9967A",
+                  "#BDB76B",
+                  "#808080",
+                  "#C0C0C0",
+                  "#FFFFFF"
+                ],
+                "name": "all.KL.bed.hg38.multires.mv5"
+              },
+              "width": 1308,
+              "height": 116
+            },
+            {
+                "type": "horizontal-multivec",
+                "uid": "cistrome-track-7",
+                "tilesetUid": "UvVPeLHuRDiYA3qwFlm7xQ",
+                "server": "https://resgen.io/api/v1",
+                "options": {
+                  "labelPosition": "hidden",
+                  "labelColor": "black",
+                  "labelTextOpacity": 0.4,
+                  "valueScaling": "linear",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "heatmapValueScaling": "log",
+                  "name": "my_file_genome_wide.multires.mv5",
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "labelShowResolution": true,
+                  "minHeight": 100,
+                  "colorbarPosition": "bottomLeft"
+                },
+                "width": 1607,
+                "height": 572
+            },
+            {
+                "type": "horizontal-gene-annotations",
+                "uid": "R6ZZ5LnEQ4ODCWZoE38maw",
+                "tilesetUid": "M9A9klpwTci5Vf4bHZ864g",
+                "server": "https://resgen.io/api/v1",
+                "options": {
+                  "labelColor": "black",
+                  "labelPosition": "hidden",
+                  "plusStrandColor": "blue",
+                  "minusStrandColor": "red",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "showMousePosition": false,
+                  "name": "gene-annotations-hg38_3d2Hebg.db",
+                  "mousePositionColor": "#999999",
+                  "fontSize": 10,
+                  "labelBackgroundColor": "#ffffff",
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "minHeight": 24,
+                  "geneAnnotationHeight": 12,
+                  "geneLabelPosition": "outside",
+                  "geneStrandSpacing": 4
+                },
+                "width": 568,
+                "height": 130
+            }
+          ],
+          "left": [],
+          "center": [],
+          "bottom": [],
+          "right": [],
+          "whole": [],
+          "gallery": []
+        },
+        "layout": {
+          "w": 12,
+          "h": 10,
+          "x": 0,
+          "y": 0,
+          "moved": false,
+          "static": false
+        },
+        "uid": "cistrome-view-7"
+      }
+    ],
+    "zoomLocks": {
+      "locksByViewUid": {},
+      "locksDict": {}
+    },
+    "locationLocks": {
+      "locksByViewUid": {},
+      "locksDict": {}
+    },
+    "valueScaleLocks": {
+      "locksByViewUid": {},
+      "locksDict": {}
+    }
+}


### PR DESCRIPTION
This pull request adds a third demo, where the horizontal-multivec track is a 'top' track rather than a 'center' track, and there is another track below it. I updated the css for the genome interval selection button so that the track below can still pan and zoom with the mouse.

Related to #144 