### PR TITLE
Minor updates on dendrogram sorting buttons

### DIFF
--- a/src/TrackRowInfoControl.js
+++ b/src/TrackRowInfoControl.js
@@ -82,12 +82,6 @@ export default function TrackRowInfoControl(props){
             icon: SORT_DESC,
             title: "Sort rows in descending order"
         });
-    } else {
-        buttons.push({
-            onClick: onSortAscClick,
-            icon: SORT_TREE,
-            title: "Sort rows by hierarchy leaf order"
-        })
     }
 
     if(onSearchRows) {

--- a/src/TrackRowInfoControl.scss
+++ b/src/TrackRowInfoControl.scss
@@ -22,7 +22,8 @@
     border-radius: 2.5px;
 }
 
-.chgw-button-sm:hover {
+.chgw-button-sm:hover,
+.chgw-button-alert:hover {
     color: #fff;
     background: #337ab7;
     opacity: 1;
@@ -32,7 +33,9 @@
     height: 35px;
     width: 35px;
     padding: 4px;
-    color: #cacaca;
+    color: #b6b6b6;
+    cursor: pointer;
+    border-radius: 2.5px;
 }
 
 .chgw-button-left {

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -7,7 +7,7 @@ import { EVENT } from "./utils/constants.js";
 import { destroyTooltip } from "./utils/tooltip.js";
 import { drawVisTitle } from "./utils/vis.js";
 import { matrixToTree } from './utils/tree.js';
-import { EXCLAMATION } from './utils/icons.js';
+import { EXCLAMATION, SORT_TREE } from './utils/icons.js';
 import { TooltipContent } from './Tooltip.js';
 
 import TrackRowInfoControl from './TrackRowInfoControl.js';
@@ -114,7 +114,6 @@ export default function TrackRowInfoVisDendrogram(props) {
                 path.linewidth = 1.5;
             }
         });
-        
 
         if(cannotAlign) {
             const rect = two.makeRect(0, 0, width, height);
@@ -225,31 +224,17 @@ export default function TrackRowInfoVisDendrogram(props) {
                     height: `${height}px`
                 }}
             />
-            <TrackRowInfoControl
-                isLeft={isLeft}
-                isVisible={isMouseHover}
-                fieldInfo={fieldInfo}
-                searchTop={null}
-                searchLeft={null}
-                onSortRows={onSortRows}
-                onFilterRows={null}
-                onSearchRows={null}
-                transformedRowInfo={transformedRowInfo}
-            />
             {cannotAlign ? (
-                <div
+                <div onClick={() => onSortRows(fieldInfo.field, fieldInfo.type, "ascending")}
                     style={{
                         position: "absolute",
-                        pointerEvents: "none",
                         top: `${height / 2.0 - 17}px`,
-                        left: `${width / 2.0 - 17}px`,
-                    }}
-                >
-                    <svg 
-                        className={`chgw-button-alert`}
-                        viewBox={EXCLAMATION.viewBox}
-                    >
-                        <path d={EXCLAMATION.path} fill="currentColor"/>
+                        left: `${width / 2.0 - 17}px`
+                    }}>
+                    <svg className={`chgw-button-alert`}
+                        viewBox={SORT_TREE.viewBox}>
+                        <title>{"Sort rows by hierarchy leaf order"}</title>
+                        <path d={SORT_TREE.path} fill="currentColor"/>
                     </svg>
                 </div>
             ) : null}

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -10,8 +10,6 @@ import { matrixToTree } from './utils/tree.js';
 import { SORT_TREE } from './utils/icons.js';
 import { TooltipContent } from './Tooltip.js';
 
-import TrackRowInfoControl from './TrackRowInfoControl.js';
-
 /**
  * Component for visualization of row info hierarchies.
  * @prop {number} left The left position of this view.

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -7,7 +7,7 @@ import { EVENT } from "./utils/constants.js";
 import { destroyTooltip } from "./utils/tooltip.js";
 import { drawVisTitle } from "./utils/vis.js";
 import { matrixToTree } from './utils/tree.js';
-import { EXCLAMATION, SORT_TREE } from './utils/icons.js';
+import { SORT_TREE } from './utils/icons.js';
 import { TooltipContent } from './Tooltip.js';
 
 import TrackRowInfoControl from './TrackRowInfoControl.js';


### PR DESCRIPTION
Alternatively uses a "sort_tree" icon on the middle for unsorted dendrograms, and clicking on the icon rearrange rows by dendrogram arrangements.

I think this is a bit easier for users to find a button to reorder rows in dendrograms.

![image](https://user-images.githubusercontent.com/9922882/75820114-c7027e00-5d69-11ea-8783-553c2791d68a.png)

![image](https://user-images.githubusercontent.com/9922882/75819848-522f4400-5d69-11ea-855d-01316eadc91d.png)

I think we can close #87.


