### PR TITLE
Add demo config with center and top tracks

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -116,7 +116,7 @@ function onViewConfigChange(viewConfigString) {
 
 export default function App() {
     
-    const [selectedDemo, setSelectedDemo] = useState(Object.keys(demos)[3]);
+    const [selectedDemo, setSelectedDemo] = useState(Object.keys(demos)[0]);
 
     return (
         <div className="app">

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -5,6 +5,7 @@ import { CistromeHGW } from '../index.js';
 import hgDemoViewConfig1 from '../viewconfigs/horizontal-multivec-1.json';
 import hgDemoViewConfig6 from '../viewconfigs/horizontal-multivec-6.json';
 import hgDemoViewConfig7 from '../viewconfigs/horizontal-multivec-7.json';
+import hgDemoViewConfig8 from '../viewconfigs/horizontal-multivec-8.json';
 
 import './App.scss';
 
@@ -81,6 +82,32 @@ const demos = {
             rowHighlight: {field: "Cell Type", type: "nominal", contains: "Stem"}
         }
     },
+    "H3K27ac Demo (1 View, Top and Center Tracks)": {
+        viewConfig: hgDemoViewConfig8,
+        options: [
+            {
+                viewId: "default",
+                trackId: "default",
+                colToolsPosition: "bottom"
+            },
+            {
+                viewId: "cistrome-view-8",
+                trackId: "cistrome-track-8-1",
+                rowInfoAttributes: [
+                    {field: "Hierarchical Clustering (Ward)", type: "tree", position: "left"},
+                    {field: "Cell Type", type: "nominal", position: "right"},
+                ]
+            },
+            {
+                viewId: "cistrome-view-8",
+                trackId: "cistrome-track-8-2",
+                rowInfoAttributes: [
+                    {field: "Hierarchical Clustering", type: "tree", position: "right"},
+                    {field: "Cell Type", type: "nominal", position: "left"},
+                ]
+            }
+        ]
+    },
 };
 
 function onViewConfigChange(viewConfigString) {
@@ -89,7 +116,7 @@ function onViewConfigChange(viewConfigString) {
 
 export default function App() {
     
-    const [selectedDemo, setSelectedDemo] = useState(Object.keys(demos)[0]);
+    const [selectedDemo, setSelectedDemo] = useState(Object.keys(demos)[3]);
 
     return (
         <div className="app">

--- a/src/demo/fakedata/index.js
+++ b/src/demo/fakedata/index.js
@@ -41,4 +41,14 @@ export default {
             rowInfo: rowInfo1
         }
     },
+    "cistrome-track-8-1": {
+        tilesetInfo: {
+            rowInfo: rowInfo1
+        }
+    },
+    "cistrome-track-8-2": {
+        tilesetInfo: {
+            rowInfo: rowInfo2
+        }
+    },
 };

--- a/src/viewconfigs/horizontal-multivec-8.json
+++ b/src/viewconfigs/horizontal-multivec-8.json
@@ -8,12 +8,12 @@
     "views": [
       {
         "initialXDomain": [
-          2795274879.8025813,
-          2826213872.0567474
+            2797755720.736449,
+            2819301812.542415
         ],
         "initialYDomain": [
-          2002993569.3469784,
-          2011171047.0976794
+            2671196920.8697634,
+            2671320441.9350777
         ],
         "tracks": {
           "top": [
@@ -32,35 +32,6 @@
               },
               "width": 1027,
               "height": 30
-            },
-            {
-              "type": "horizontal-gene-annotations",
-              "uid": "R6ZZ5LnEQ4ODCWZoE38maw",
-              "tilesetUid": "M9A9klpwTci5Vf4bHZ864g",
-              "server": "https://resgen.io/api/v1",
-              "options": {
-                "labelColor": "black",
-                "labelPosition": "hidden",
-                "plusStrandColor": "blue",
-                "minusStrandColor": "red",
-                "trackBorderWidth": 0,
-                "trackBorderColor": "black",
-                "showMousePosition": false,
-                "name": "gene-annotations-hg38_3d2Hebg.db",
-                "mousePositionColor": "#999999",
-                "fontSize": 10,
-                "labelBackgroundColor": "#ffffff",
-                "labelLeftMargin": 0,
-                "labelRightMargin": 0,
-                "labelTopMargin": 0,
-                "labelBottomMargin": 0,
-                "minHeight": 24,
-                "geneAnnotationHeight": 12,
-                "geneLabelPosition": "outside",
-                "geneStrandSpacing": 4
-              },
-              "width": 568,
-              "height": 70
             },
             {
               "type": "horizontal-bar",
@@ -84,8 +55,7 @@
                 "labelTopMargin": 0,
                 "labelBottomMargin": 0,
                 "labelShowResolution": false,
-                "axisLabelFormatting": "scientific",
-                "labelShowAssembly": true
+                "axisLabelFormatting": "scientific"
               },
               "width": 568,
               "height": 42
@@ -127,38 +97,63 @@
               },
               "width": 1308,
               "height": 116
+            },
+            {
+                "type": "horizontal-multivec",
+                "uid": "cistrome-track-8-1",
+                "tilesetUid": "UvVPeLHuRDiYA3qwFlm7xQ",
+                "server": "https://resgen.io/api/v1",
+                "options": {
+                  "labelPosition": "hidden",
+                  "labelColor": "black",
+                  "labelTextOpacity": 0.4,
+                  "valueScaling": "linear",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "heatmapValueScaling": "log",
+                  "name": "my_file_genome_wide.multires.mv5",
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "labelShowResolution": true,
+                  "minHeight": 100,
+                  "colorbarPosition": "bottomLeft"
+                },
+                "width": 1607,
+                "height": 272
             }
           ],
           "left": [],
           "center": [
             {
-              "type": "horizontal-multivec",
-              "uid": "cistrome-track-2",
-              "tilesetUid": "A62Qp9QtSdS4zhZxp6PHDw",
-              "server": "https://resgen.io/api/v1",
-              "options": {
-                "labelPosition": "hidden",
-                "labelColor": "black",
-                "labelTextOpacity": 0.4,
-                "valueScaling": "linear",
-                "trackBorderWidth": 0,
-                "trackBorderColor": "black",
-                "heatmapValueScaling": "log",
-                "name": "chr1_127epigenomes_15observedStates.12.multires.mv5",
-                "labelLeftMargin": 0,
-                "labelRightMargin": 0,
-                "labelTopMargin": 0,
-                "labelBottomMargin": 0,
-                "labelShowResolution": true,
-                "minHeight": 100,
-                "colorbarPosition": "topLeft",
-                "labelShowAssembly": true,
-                "colorbarBackgroundColor": "#ffffff",
-                "scaleStartPercent": "0.00000",
-                "scaleEndPercent": "1.00000"
-              },
-              "width": 1607,
-              "height": 482
+                "type": "horizontal-multivec",
+                "uid": "cistrome-track-8-2",
+                "tilesetUid": "A62Qp9QtSdS4zhZxp6PHDw",
+                "server": "https://resgen.io/api/v1",
+                "options": {
+                  "labelPosition": "hidden",
+                  "labelColor": "black",
+                  "labelTextOpacity": 0.4,
+                  "valueScaling": "linear",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "heatmapValueScaling": "log",
+                  "name": "chr1_127epigenomes_15observedStates.12.multires.mv5",
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "labelShowResolution": true,
+                  "minHeight": 100,
+                  "colorbarPosition": "topLeft",
+                  "labelShowAssembly": true,
+                  "colorbarBackgroundColor": "#ffffff",
+                  "scaleStartPercent": "0.00000",
+                  "scaleEndPercent": "1.00000"
+                },
+                "width": 1607,
+                "height": 282
             }
           ],
           "bottom": [],
@@ -168,13 +163,13 @@
         },
         "layout": {
           "w": 12,
-          "h": 71,
+          "h": 10,
           "x": 0,
           "y": 0,
           "moved": false,
           "static": false
         },
-        "uid": "cistrome-view-2"
+        "uid": "cistrome-view-8"
       }
     ],
     "zoomLocks": {


### PR DESCRIPTION
This new demo has two horizontal-multivec tracks in the same higlass view, and each track is using different metadata.

Fixes #144 