### PR TITLE
Only show width resizer on hover

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -3,20 +3,21 @@ toc:
 - CistromeHGW
 - name: React Components (internal)
 - CistromeHGWConsumer
+- InfoProvider
 - Tooltip
 - TrackColSelectionInfo
 - TrackColTools
-- TrackRowInfoControl
 - TrackRowHighlight
 - TrackRowInfo
-- TrackRowInfoVisNominalBar
-- TrackRowInfoVisQuantitativeBar
+- TrackRowInfoControl
+- TrackRowInfoVis
 - TrackRowInfoVisDendrogram
 - TrackRowInfoVisLink
+- TrackRowInfoVisNominalBar
+- TrackRowInfoVisQuantitativeBar
 - TrackRowSearch
-- SuggestionWithHighlight
 - TrackWrapper
-- InfoProvider
+- SuggestionWithHighlight
 - name: Functions (internal)
 - validateWrapperOptions
 - processWrapperOptions

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -1,21 +1,11 @@
-import React, { useRef, createRef, useState, useEffect} from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import d3 from './utils/d3.js';
 import { modifyItemInArray } from './utils/array.js';
-import TrackRowInfoVisNominalBar from './TrackRowInfoVisNominalBar.js';
-import TrackRowInfoVisQuantitativeBar from './TrackRowInfoVisQuantitativeBar.js';
-import TrackRowInfoVisLink from './TrackRowInfoVisLink.js';
-import TrackRowInfoVisDendrogram from './TrackRowInfoVisDendrogram.js';
-import './TrackResizer.scss';
 
-const fieldTypeToVisComponent = {
-    "nominal": TrackRowInfoVisNominalBar,
-    "quantitative": TrackRowInfoVisQuantitativeBar,
-    "url": TrackRowInfoVisLink,
-    "tree": TrackRowInfoVisDendrogram
-};
+import TrackRowInfoVis from "./TrackRowInfoVis.js";
 
 /**
- * Parent component for visualization of row info attribute values.
+ * Parent component for visualization of multiple row info attribute values, on a particular side (left/right).
  * @prop {number} trackX The track horizontal offset.
  * @prop {number} trackY The track vertical offset.
  * @prop {number} trackWidth The track width.
@@ -48,148 +38,73 @@ export default function TrackRowInfo(props) {
     } = props;
 
     // Dimensions
-    const defaultUnitWidth = 100;
-    const marginForMouseEvent = 20;
     const isLeft = rowInfoPosition === "left";
-    const top = trackY;
-    let unitWidths = [];    // Store default unit width for each vertical tracks
-    rowInfoAttributes.forEach((fieldInfo) => {
-        unitWidths.push({
-            field: fieldInfo.field,
-            type: fieldInfo.type,
-            width: defaultUnitWidth
-        });
-    });
-    const [widths, setWidths] = useState(unitWidths);
-    const totalWidth = d3.sum(widths.map(d => d.width));
-    const height = trackHeight;
-    const left = isLeft ? trackX - totalWidth : trackX + trackWidth;
 
-    const divRef = useRef();
-    const resizerRef = useRef([...Array(rowInfoAttributes.length)].map(() => createRef()));
-    const [resizingIndex, setResizingIndex] = useState(-1);
+    const top = trackY;
+    const height = trackHeight;
+    const defaultUnitWidth = 100;
+    const [unitWidths, setUnitWidths] = useState(rowInfoAttributes.map(() => defaultUnitWidth));
+
+
+    const lrKey = (isLeft ? "right" : "left");
+    const lrVal = (isLeft ? trackX + trackWidth : trackX + trackWidth);
+
+    function setUnitWidthByIndex(i, val) {
+        const newUnitWidths = Array.from(unitWidths);
+        newUnitWidths[i] = val;
+        setUnitWidths(newUnitWidths);
+    }
+
+    
     
     // Determine position of each dimension.
-    let trackProps = [], currentLeft = 0;
+    let trackProps = [], currentLr = 0;
     rowInfoAttributes.forEach((attribute, i) => {
-        const fieldInfo = isLeft ? rowInfoAttributes[rowInfoAttributes.length - i - 1] : attribute;
-        const width = widths.find(d => {
-            if(Array.isArray(d.field) && Array.isArray(fieldInfo.field)) {
-                return d.field.join() === fieldInfo.field.join() && d.type === fieldInfo.type;
-            } else {
-                return d.field === fieldInfo.field && d.type === fieldInfo.type;
-            }
-        }).width;
-        
-        // Title suffix.
-        let titleSuffix = "";
-        const sortInfo = rowSort ? rowSort.find(d => d.field === fieldInfo.field) : undefined;
-        if(sortInfo) {
-            titleSuffix += ` | sorted (${sortInfo.order})`;
-        }
-        const filterInfo = rowFilter ? rowFilter.filter(d => d.field === fieldInfo.field) : undefined;
-        if(filterInfo && filterInfo.length > 0) {
-            titleSuffix += ` | filtered by ${filterInfo.map(d => `"${d.contains}"`).join(', ')}`;
-        }
-        if(rowHighlight && rowHighlight.field === fieldInfo.field && rowHighlight.contains.length > 0) {
-            titleSuffix += ` | highlighted by "${rowHighlight.contains}"`;
-        }
-
+        const fieldInfo = attribute;
+        const width = unitWidths[i];
         trackProps.push({
-            left: currentLeft, top: 0, width, height,
+            top: 0,
+            [lrKey]: currentLr, 
+            width,
+            height,
             fieldInfo,
-            isLeft,
-            titleSuffix
         });
-        currentLeft += width;
+        currentLr += width;
     });
-    
-    let resizers = trackProps.map((d, i) => {
-        const resizerWidth = 4, resizerHeight = 10, margin = 2;
-        return (
-            <div
-                ref={resizerRef.current[i]}
-                key={i}
-                className="visualization-resizer"
-                style={{    
-                    top: `${d.top + (d.height - resizerHeight) / 2.0}px`,
-                    left: `${isLeft ? marginForMouseEvent + d.left + margin : d.left + d.width - resizerWidth - margin}px`,
-                    height: `${resizerHeight}px`,
-                    width: `${resizerWidth}px`
-                }}
-            />
-        );
-    });
-
-    useEffect(() => {
-        const div = divRef.current;
-
-        resizerRef.current.forEach((resizer, i) => {
-            d3.select(resizer.current).on("mousedown", () => setResizingIndex(i));
-        });
-
-        d3.select(div).on("mouseup", () => setResizingIndex(-1));
-
-        d3.select(div).on("mousemove", () => {
-            if(resizingIndex !== -1) {
-                const { left: trackLeft, width: trackWidth } = trackProps[resizingIndex];
-                const { field, type } = trackProps[resizingIndex].fieldInfo;
-                const [mouseX, mouseY] = d3.mouse(div);
-                let newWidth = isLeft ? trackWidth - (mouseX - trackLeft - marginForMouseEvent) : (mouseX - trackLeft);
-                const minWidth = 40;
-                if(newWidth < minWidth) {
-                    newWidth = minWidth;
-                }
-                const mIdx = widths.indexOf(widths.find(d => {
-                    if(Array.isArray(d.field) && Array.isArray(field)) {
-                        return d.field.join() === field.join() && d.type === type;
-                    } else {
-                        return d.field === field && d.type === type;
-                    }
-                }));
-                if(mIdx !== -1){
-                    setWidths(modifyItemInArray(widths, mIdx, {
-                        field, type,
-                        width: newWidth
-                    }));
-                }
-            }
-        });
-
-        d3.select(div).on("mouseleave", () => setResizingIndex(-1));
-    })
 
     console.log("TrackRowInfo.render");
     return (
         <div
-            ref={divRef}
-            className="cistrome-hgw-child"
             style={{
+                border: '1px solid green',
+                position: 'absolute',
                 top: `${top}px`,
-                left: `${left - (isLeft ? marginForMouseEvent : 0)}px`, 
-                width: `${totalWidth + marginForMouseEvent}px`,
-                height: `${height}px`,
+                [lrKey]: `${lrVal}px`,
+                height: `${height}px`
             }}
         >
-            {trackProps.map((d, i) => React.createElement(
-                fieldTypeToVisComponent[d.fieldInfo.type],
-                {
-                    key: i,
-                    left: d.left + (isLeft ? marginForMouseEvent : 0),
-                    top: d.top,
-                    width: d.width,
-                    height: d.height,
-                    isLeft: d.isLeft,
-                    fieldInfo: d.fieldInfo,
-                    transformedRowInfo,
-                    titleSuffix: d.titleSuffix,
-                    onSortRows,
-                    onSearchRows,
-                    onFilterRows,
-                    drawRegister,
-                }
+            {trackProps.map((d, i) => (
+                <TrackRowInfoVis 
+                    key={i}
+                    top={d.top}
+                    left={d.left}
+                    right={d.right}
+                    width={d.width}
+                    height={d.height}
+                    isLeft={isLeft}
+                    fieldInfo={d.fieldInfo}
+                    transformedRowInfo={transformedRowInfo}
+                    rowSort={rowSort}
+                    rowFilter={rowFilter}
+                    rowHighlight={rowHighlight}
+                    onSortRows={onSortRows}
+                    onSearchRows={onSearchRows}
+                    onFilterRows={onFilterRows}
+                    drawRegister={drawRegister}
+                    
+                    onWidthChanged={(val) => setUnitWidthByIndex(i, val)}
+                />
             ))}
-            {resizers}
         </div>
     );
 }

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -15,6 +15,7 @@ import TrackRowInfoVis from "./TrackRowInfoVis.js";
  * @prop {string} rowInfoPosition The value of the `rowInfoPosition` option.
  * @prop {object} rowSort The options for sorting rows.
  * @prop {object} rowFilter The options for filtering rows.
+ * @prop {object} rowHighlight The options for highlighting rows.
  * @prop {function} onSortRows The function to call upon a sort interaction.
  * @prop {function} onSearchRows The function to call upon a search interaction.
  * @prop {function} onFilterRows The function to call upon a filter interaction.
@@ -44,10 +45,9 @@ export default function TrackRowInfo(props) {
     const height = trackHeight;
     const defaultUnitWidth = 100;
     const [unitWidths, setUnitWidths] = useState(rowInfoAttributes.map(() => defaultUnitWidth));
-
-
-    const lrKey = (isLeft ? "right" : "left");
-    const lrVal = (isLeft ? trackX + trackWidth : trackX + trackWidth);
+    
+    const totalWidth = d3.sum(unitWidths);
+    const left = isLeft ? trackX - totalWidth : trackX + trackWidth;
 
     function setUnitWidthByIndex(i, val) {
         const newUnitWidths = Array.from(unitWidths);
@@ -58,28 +58,27 @@ export default function TrackRowInfo(props) {
     
     
     // Determine position of each dimension.
-    let trackProps = [], currentLr = 0;
+    let trackProps = [], currentLeft = 0;
     rowInfoAttributes.forEach((attribute, i) => {
-        const fieldInfo = attribute;
+        const fieldInfo = isLeft ? rowInfoAttributes[rowInfoAttributes.length - i - 1] : attribute;
         const width = unitWidths[i];
         trackProps.push({
             top: 0,
-            [lrKey]: currentLr, 
+            left: currentLeft, 
             width,
             height,
             fieldInfo,
         });
-        currentLr += width;
+        currentLeft += width;
     });
 
     console.log("TrackRowInfo.render");
     return (
         <div
             style={{
-                border: '1px solid green',
                 position: 'absolute',
                 top: `${top}px`,
-                [lrKey]: `${lrVal}px`,
+                left: `${left}px`,
                 height: `${height}px`
             }}
         >
@@ -88,7 +87,6 @@ export default function TrackRowInfo(props) {
                     key={i}
                     top={d.top}
                     left={d.left}
-                    right={d.right}
                     width={d.width}
                     height={d.height}
                     isLeft={isLeft}

--- a/src/TrackRowInfoVis.js
+++ b/src/TrackRowInfoVis.js
@@ -1,0 +1,147 @@
+import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react';
+import d3 from './utils/d3.js';
+
+import TrackRowInfoVisNominalBar from './TrackRowInfoVisNominalBar.js';
+import TrackRowInfoVisQuantitativeBar from './TrackRowInfoVisQuantitativeBar.js';
+import TrackRowInfoVisLink from './TrackRowInfoVisLink.js';
+import TrackRowInfoVisDendrogram from './TrackRowInfoVisDendrogram.js';
+import './TrackResizer.scss';
+
+
+const fieldTypeToVisComponent = {
+    "nominal": TrackRowInfoVisNominalBar,
+    "quantitative": TrackRowInfoVisQuantitativeBar,
+    "url": TrackRowInfoVisLink,
+    "tree": TrackRowInfoVisDendrogram
+};
+
+/**
+ * General component for visualization of a particular row info attribute.
+ * @prop {number} left The left position of this view.
+ * @prop {number} top The top position of this view.
+ * @prop {number} width The width of this view.
+ * @prop {number} height The height of this view.
+ * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object} fieldInfo The name and type of data field.
+ * @prop {boolean} isLeft Is this view on the left side of the track?
+ * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
+ * @prop {function} onSortRows The function to call upon a sort interaction.
+ * @prop {function} onSearchRows The function to call upon a search interaction.
+ * @prop {function} onFilterRows The function to call upon a filter interaction.
+ * @prop {function} drawRegister The function for child components to call to register their draw functions.
+ */
+export default function TrackRowInfoVis(props) {
+    const {
+        left, right, top, width, height,
+        fieldInfo,
+        isLeft,
+        transformedRowInfo,
+        rowSort,
+        rowFilter,
+        rowHighlight,
+        onSortRows,
+        onSearchRows,
+        onFilterRows,
+        drawRegister,
+        onWidthChanged
+    } = props;
+
+    const minWidth = 40;
+    const resizerWidth = 4
+    const resizerHeight = 10
+    const resizerMargin = 2;
+    const marginForMouseEvent = 20;
+
+    const lrKey = (isLeft ? "right" : "left");
+    const lrVal = (isLeft ? right : left);
+
+    const resizerRef = useRef();
+
+    const [isResizing, setIsResizing] = useState(false);
+
+    const dragged = useCallback(() => {
+        const event = d3.event;
+        const mouseX = (isLeft ? event.x : event.x);
+
+        let newWidth = isLeft ? width - mouseX : mouseX;
+        if(newWidth < minWidth) {
+            newWidth = minWidth;
+        }
+        console.log(event.x, event.dx)
+        console.log(newWidth);
+        // Emit the new width value to the parent component.
+        onWidthChanged(newWidth);
+    }, [onWidthChanged]);
+
+    useEffect(() => {
+        const resizer = resizerRef.current;
+
+        console.log("effect")
+
+        const drag = d3.drag()
+            .on("start", () => setIsResizing(true))
+            .on("drag", dragged)
+            .on("end", () => setIsResizing(false));
+
+        d3.select(resizer).call(drag);
+
+    }, [dragged]);
+
+    // Determine the title suffix.
+    let titleSuffix = "";
+    const sortInfo = rowSort ? rowSort.find(d => d.field === fieldInfo.field) : undefined;
+    if(sortInfo) {
+        titleSuffix += ` | sorted (${sortInfo.order})`;
+    }
+    const filterInfo = rowFilter ? rowFilter.filter(d => d.field === fieldInfo.field) : undefined;
+    if(filterInfo && filterInfo.length > 0) {
+        titleSuffix += ` | filtered by ${filterInfo.map(d => `"${d.contains}"`).join(', ')}`;
+    }
+    if(rowHighlight && rowHighlight.field === fieldInfo.field && rowHighlight.contains.length > 0) {
+        titleSuffix += ` | highlighted by "${rowHighlight.contains}"`;
+    }
+
+    const resizer = (
+        <div
+            ref={resizerRef}
+            className="visualization-resizer"
+            style={{
+                top: `${top + (height - resizerHeight) / 2.0}px`,
+                left: `${isLeft ? resizerMargin : width - resizerWidth - resizerMargin}px`,
+                height: `${resizerHeight}px`,
+                width: `${resizerWidth}px`
+            }}
+        />
+    );
+
+    return (
+        <div 
+            style={{
+                border: '1px solid red',
+                position: 'absolute',
+                top: `${top}px`,
+                [lrKey]: `${lrVal}px`, 
+                height: `${height}px`,
+            }}
+        >
+            {React.createElement(
+                fieldTypeToVisComponent[fieldInfo.type],
+                {
+                    [lrKey]: lrVal,
+                    top: 0,
+                    width,
+                    height,
+                    isLeft,
+                    fieldInfo,
+                    transformedRowInfo,
+                    titleSuffix,
+                    onSortRows,
+                    onSearchRows,
+                    onFilterRows,
+                    drawRegister,
+                }
+            )}
+            {resizer}
+        </div>
+    );
+}

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -25,7 +25,7 @@ import { TooltipContent } from './Tooltip.js';
  */
 export default function TrackRowInfoVisDendrogram(props) {
     const {
-        left, top, width, height,
+        left, right, top, width, height,
         fieldInfo,
         isLeft,
         transformedRowInfo,
@@ -204,10 +204,8 @@ export default function TrackRowInfoVisDendrogram(props) {
     return (
         <div
             ref={divRef}
-            className="cistrome-hgw-child"
             style={{
-                top: `${top}px`,
-                left: `${left}px`, 
+                position: 'relative',
                 width: `${width}px`,
                 height: `${height}px`,
             }}
@@ -215,9 +213,8 @@ export default function TrackRowInfoVisDendrogram(props) {
             <canvas
                 ref={canvasRef}
                 style={{
-                    position: "absolute",
+                    position: "relative",
                     top: 0,
-                    left: 0, 
                     width: `${width}px`,
                     height: `${height}px`
                 }}

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -25,7 +25,7 @@ import { TooltipContent } from './Tooltip.js';
  */
 export default function TrackRowInfoVisDendrogram(props) {
     const {
-        left, right, top, width, height,
+        left, top, width, height,
         fieldInfo,
         isLeft,
         transformedRowInfo,
@@ -48,7 +48,6 @@ export default function TrackRowInfoVisDendrogram(props) {
 
     // Data, layouts and styles
     const { field } = fieldInfo;
-    const isNominal = false;
 
     // Process the hierarchy data. Result will be null if the tree leaves
     // cannot be aligned based on the current rowInfo ordering.

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -144,10 +144,8 @@ export default function TrackRowInfoVisLink(props) {
     return (
         <div
             ref={divRef}
-            className="cistrome-hgw-child"
             style={{
-                top: `${top}px`,
-                left: `${left}px`, 
+                position: 'relative',
                 width: `${width}px`,
                 height: `${height}px`
             }}

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -176,10 +176,8 @@ export default function TrackRowInfoVisNominalBar(props) {
     return (
         <div
             ref={divRef}
-            className="cistrome-hgw-child"
             style={{
-                top: `${top}px`,
-                left: `${left}px`, 
+                position: 'relative',
                 width: `${width}px`,
                 height: `${height}px`,
             }}

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -274,10 +274,9 @@ export default function TrackRowInfoVisQuantitativeBar(props) {
     return (
         <div
             ref={divRef}
-            className="cistrome-hgw-child"
             style={{
                 top: `${top - axisHeight}px`,
-                left: `${left}px`, 
+                position: 'relative',
                 width: `${width}px`,
                 height: `${height + axisHeight}px`,
             }}

--- a/src/utils/d3.js
+++ b/src/utils/d3.js
@@ -15,6 +15,7 @@ import { extent, sum } from "d3-array";
 import { hsl } from "d3-color";
 import { hierarchy, cluster } from "d3-hierarchy";
 import { Delaunay as delaunay } from "d3-delaunay";
+import { drag } from "d3-drag";
 
 /*
  * Same as `d3.scaleBand` but also supports `invert()`.
@@ -43,5 +44,6 @@ export default {
     hsl,
     hierarchy,
     cluster,
-    delaunay
+    delaunay,
+    drag
 };


### PR DESCRIPTION
This pull request makes a new component, TrackRowInfoVis, which is a container for an individual visualization component and its resizer element. So now TrackRowInfo can be much simpler, and this allows us to show/hide the resizer component when the visualization component is hovered, which fixes #158 

It also changes the resizing logic to use d3-drag https://github.com/d3/d3-drag