### PR TITLE
Some refactoring of the datatable

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -4,9 +4,10 @@ toc:
 - name: React Components (internal)
 - CistromeHGWConsumer
 - InfoProvider
-- Tooltip
 - DataTable
+- DataTableForIntervalTFs
 - ContextMenu
+- Tooltip
 - TrackColSelectionInfo
 - TrackColTools
 - TrackRowHighlight
@@ -42,6 +43,9 @@ toc:
 - drawVisTitle
 - matrixToTree
 - createReducer
+- validateIntervalParams
+- makeDBToolkitIntervalAPIURL
+- requestIntervalTFs
 - name: Classes (internal)
 - Two
 - TwoRectangle

--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import "./TrackRowInfoControl.scss";
+import "./DataTable.scss";
 
 /**
  * Component for data table.
@@ -10,11 +11,17 @@ import "./TrackRowInfoControl.scss";
  * @prop {number} height The height of this view.
  * @prop {array} rows Array of rows to render data table.
  * @prop {array} columns Array of column names in data table.
+ * @prop {string} title A title for the table. Optional.
+ * @prop {string} subtitle A subtitle for the table. Optional.
+ * @prop {boolean} isLoading Whether the data is still loading, in which case show a spinner.
  */
 export default function DataTable(props) {
     const {
         left, top, width, height,
-        rows, columns
+        rows = [], columns = [],
+        title = "Data Preview",
+        subtitle,
+        isLoading = false
     } = props;
 
     const head = columns.map((c, j) => {
@@ -35,7 +42,14 @@ export default function DataTable(props) {
                 left, top, width, height
             }}
         >
-            <h4>Data Preview</h4>   
+            <h4 className="chw-table-title">{title}</h4>
+            <span className="chw-table-subtitle">
+                {isLoading ? (
+                    <span className="chw-progress-ring" />
+                ) : (subtitle ? (
+                    <b>{subtitle}</b>
+                ) : null)}
+            </span>
             <div
                 style={{
                     height: height - 40,

--- a/src/DataTable.scss
+++ b/src/DataTable.scss
@@ -1,0 +1,37 @@
+.chw-table {
+    width: 100%;
+    border-collapse: collapse;
+    border: none;
+    padding-bottom: 10px;
+    tr:nth-child(even) {
+        background: #eeeeee;
+    }
+    tr:hover {
+        background: #e6f3ff80;
+    }
+    th {
+        height: 30px;
+        padding: 0px 4px;
+    }
+    tr, td {
+        padding: 0px 4px;
+    }
+}
+
+.chw-table-title {
+    display: inline-block;
+}
+
+.chw-table-subtitle {
+    display: inline-block;
+    color: gray;
+    margin-left: 15px;
+    position: relative;
+
+    .chw-progress-ring {
+        display: inline-block;
+        left: auto;
+        margin-left: 0px;
+        top: 4px;
+    }
+}

--- a/src/DataTableForIntervalTFs.js
+++ b/src/DataTableForIntervalTFs.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+
+import DataTable from "./DataTable.js";
+
+import { requestIntervalTFs } from './utils/cistrome.js';
+
+/**
+ * Wrapper around <DataTable />, specific for showing the TF binding interval request results.
+ * @prop {number} left The left position of this view.
+ * @prop {number} top The top position of this view.
+ * @prop {number} width The width of this view.
+ * @prop {number} height The height of this view.
+ * @prop {object} intervalParams The interval request parameters.
+ * @prop {string} intervalParams.assembly
+ * @prop {string} intervalParams.chrStartName
+ * @prop {number} intervalParams.chrStartPos
+ * @prop {string} intervalParams.chrEndName
+ * @prop {number} intervalParams.chrEndPos
+ */
+export default function DataTableForIntervalTFs(props) {
+    const {
+        left, top, width, height,
+        intervalParams
+    } = props;
+
+    const {
+        assembly, 
+        chrStartName, 
+        chrStartPos, 
+        chrEndName, 
+        chrEndPos
+    } = intervalParams;
+
+    const [requestStatus, setRequestStatus] = useState(null);
+    const [dataTableRows, setDataTableRows] = useState([]);
+    const [dataTableColumns, setDataTableColumns] = useState([]);
+
+    useEffect(() => {
+        let didUnmount = false;
+        setRequestStatus({ msg: "Receiving Cistrome DB API response...", isLoading: true });
+        if(intervalParams) {
+            requestIntervalTFs(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos)
+                .then(([rows, columns]) => {
+                    if(didUnmount) return;
+                    setDataTableRows(rows);
+                    setDataTableColumns(columns);
+
+                    const msg = `For interval ${chrStartName}:${chrStartPos}-${chrEndPos}`;
+                    setRequestStatus({ msg, isLoading: false });
+                })
+                .catch((msg) => {
+                    if(didUnmount) return;
+                    setRequestStatus({ msg, isLoading: false });
+                })
+        }
+
+        return (() => { didUnmount = true; });
+    }, [intervalParams]);
+
+    return (requestStatus ? (
+        <DataTable 
+            left={left}
+            top={top}
+            width={width}
+            height={height}
+            title={"TFs from Cistrome DB"}
+            subtitle={requestStatus.msg}
+            isLoading={requestStatus.isLoading}
+            rows={dataTableRows}
+            columns={dataTableColumns}
+        />
+    ) : null);
+}

--- a/src/TrackColSelectionInfo.js
+++ b/src/TrackColSelectionInfo.js
@@ -3,43 +3,11 @@ import d3 from './utils/d3.js';
 import Two from './utils/two.js';
 
 import { resolveIntervalCoordinates } from './utils/genome.js';
-import { CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE } from './utils/constants.js';
+import { validateIntervalParams } from './utils/cistrome.js';
 import { SEARCH } from './utils/icons.js';
 
 import './TrackColSelectionInfo.scss';
 import './TrackRowInfoControl.scss';
-
-function makeDBToolkitURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
-    if(!chrStartName || !chrStartPos || !chrEndName || !chrEndPos) {
-        return null;
-    }
-    // Generate a URL for the cistrome DB toolkit site.
-    if(chrStartName !== chrEndName) {
-        // Bail out, interval spans across more than one chromosome.
-        return null;
-    }
-    if(chrEndPos - chrStartPos > CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE) {
-        // Bail out, interval is too large for dbtoolkit's interval search.
-        return null;
-    }
-    return `http://dbtoolkit.cistrome.org/?specie=${assembly}&factor=tf&interval=${chrStartName}%3A${chrStartPos}-${chrEndPos}`;
-}
-
-function makeDBToolkitAPIURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
-    if(!chrStartName || !chrStartPos || !chrEndName || !chrEndPos) {
-        return null;
-    }
-    if(chrStartName !== chrEndName) {
-        // Bail out, interval spans across more than one chromosome.
-        return null;
-    }
-    if(chrEndPos - chrStartPos > CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE) {
-        // Bail out, interval is too large for dbtoolkit's interval search.
-        return null;
-    }
-    // Generate a URL for the cistrome DB toolkit API.
-    return `http://dbtoolkit.cistrome.org/api_interval?species=${assembly}&factor=tf&interval=${chrStartName}:${chrStartPos}-${chrEndPos}`;
-}
 
 const numberFormatter = d3.format(",");
 
@@ -50,6 +18,7 @@ const numberFormatter = d3.format(",");
  * @prop {object} projectionTrack A `viewport-projection-horizontal` track object.
  * @prop {(string|null)} trackAssembly The genome assembly/coordSystem value obtained from the associated `horizontal-multivec` track.
  * @prop {string} colToolsPosition The value of the colToolsPosition option.
+ * @prop {function} onRequestIntervalTFs The function to call upon making a request for further interval transcription factor data.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackColSelectionInfo(props) {
@@ -61,7 +30,6 @@ export default function TrackColSelectionInfo(props) {
         trackAssembly,
         colToolsPosition,
         onRequestIntervalTFs,
-        APIRequestStatus,
         drawRegister
     } = props;
     
@@ -152,8 +120,10 @@ export default function TrackColSelectionInfo(props) {
         return teardown;
     });
 
-    const dbToolkitURL = makeDBToolkitURL(trackAssembly, chrStartName, chrStartPos, chrEndName, chrEndPos);
-    const dbToolkitAPIURL = makeDBToolkitAPIURL(trackAssembly, chrStartName, chrStartPos, chrEndName, chrEndPos);
+    const { 
+        msg: intervalInvalidMsg, 
+        success: intervalValid 
+    } = validateIntervalParams(trackAssembly, chrStartName, chrStartPos, chrEndName, chrEndPos);
 
     return (
         <div
@@ -184,11 +154,16 @@ export default function TrackColSelectionInfo(props) {
                     height: `${height/6}px`
                 }}
             >
-                {(!chrStartName || !chrStartPos || !chrEndName || !chrEndPos || !["hg38", "mm10"].includes(trackAssembly)) ? null : (
-                    dbToolkitAPIURL ? (
+                {intervalValid ? (
                         <div>
                             <div className="chgw-button"
-                                onClick={() => onRequestIntervalTFs(dbToolkitAPIURL)}>
+                                onClick={() => onRequestIntervalTFs({
+                                    assembly: trackAssembly,
+                                    chrStartName,
+                                    chrStartPos,
+                                    chrEndName,
+                                    chrEndPos
+                                })}>
                                 <svg className="chgw-button-sm chgw-search-button chgw-button-static"
                                     style={{ verticalAlign: "bottom", padding: "4px" }}
                                     viewBox={SEARCH.viewBox}>
@@ -196,23 +171,12 @@ export default function TrackColSelectionInfo(props) {
                                 </svg>
                                 Search bind TFs from Cistrome DB
                             </div>
-                            {APIRequestStatus && APIRequestStatus.msg ? 
-                                <div style={{ color: "gray", marginTop: "10px" }}>
-                                    <b>{APIRequestStatus.msg}</b>
-                                </div>
-                                : null}
-                            {APIRequestStatus && APIRequestStatus.isLoading ? 
-                                <div className="chw-progress-ring" 
-                                    style={{ marginTop: "10px" }}
-                                /> 
-                                : null}
                         </div>
                     ) : (
                         <p className="col-selection-info-disabled">
-                            Search requires interval &le; 2 Mb
+                            {intervalInvalidMsg}
                         </p>
-                    )
-                )}
+                    )}
             </div>
         </div>
     );

--- a/src/TrackColTools.js
+++ b/src/TrackColTools.js
@@ -15,6 +15,7 @@ import './TrackColTools.scss';
  *                                are siblings of `multivecTrack` (children of the same `combined` track).
  * @prop {string} colToolsPosition The value of the `colToolsPosition` option.
  * @prop {function} onSelectGenomicInterval The function to call upon selection of a genomic interval.
+ * @prop {function} onRequestIntervalTFs The function to call upon making a request for further interval transcription factor data.
  * @prop {function} drawRegister The function for child components to call to register their draw functions.
  */
 export default function TrackColTools(props) {
@@ -28,7 +29,6 @@ export default function TrackColTools(props) {
         colToolsPosition,
         onSelectGenomicInterval,
         onRequestIntervalTFs,
-        APIRequestStatus,
         drawRegister
     } = props;
 
@@ -80,7 +80,6 @@ export default function TrackColTools(props) {
                                 trackAssembly={trackAssembly}
                                 projectionTrack={siblingTrack}
                                 onRequestIntervalTFs={onRequestIntervalTFs}
-                                APIRequestStatus={APIRequestStatus}
                                 drawRegister={drawRegister}
                             />
                         ))}

--- a/src/TrackRowInfoControl.scss
+++ b/src/TrackRowInfoControl.scss
@@ -14,25 +14,6 @@
     opacity: 1;
 }
 
-.chw-table {
-    width: 100%;
-    border-collapse: collapse;
-    border: none;
-    padding-bottom: 10px;
-    tr:nth-child(even) {
-        background: #eeeeee;
-    }
-    tr:hover {
-        background: #e6f3ff80;
-    }
-    th {
-        height: 30px;
-        padding: 0px 4px;
-    }
-    tr, td {
-        padding: 0px 4px;
-    }
-}
 
 .chgw-button {
     display: inline;

--- a/src/utils/cistrome.js
+++ b/src/utils/cistrome.js
@@ -1,0 +1,84 @@
+
+export const CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE = 2000000;
+/**
+ * Check if interval request parameters are valid, and will be able to generate a good API url.
+ * @param {string} assembly
+ * @param {string} chrStartName
+ * @param {number} chrStartPos
+ * @param {string} chrEndName
+ * @param {number} chrEndPos
+ * @returns {object} Status object, for example `{ msg: "Some error", success: false }`.
+ */
+export function validateIntervalParams(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
+    let msg;
+    let success = false;
+    if(!assembly) {
+        msg = "No assembly value found.";
+    } else if (!["hg38", "mm10"].includes(assembly)) {
+        msg = "Unsupported assembly encountered.";
+    } else if(!chrStartName || !chrStartPos || !chrEndName || !chrEndPos) {
+        msg = "Not enough chromosome parameters.";
+    } else if(chrStartName !== chrEndName) {
+        msg = "Interval spans across more than one chromosome.";
+    } else if(chrEndPos - chrStartPos > CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE) {
+        msg = "Search requires interval < 2 Mb";
+    } else {
+        msg = "Success";
+        success = true;
+    }
+    return { msg, success };
+}
+
+/**
+ *  Generate a URL for the cistrome DB toolkit API.
+ * @param {string} assembly
+ * @param {string} chrStartName
+ * @param {number} chrStartPos
+ * @param {string} chrEndName
+ * @param {number} chrEndPos
+ * @returns {string} The url.
+ */
+export function makeDBToolkitIntervalAPIURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
+    return `http://dbtoolkit.cistrome.org/api_interval?species=${assembly}&factor=tf&interval=${chrStartName}:${chrStartPos}-${chrEndPos}`;
+}
+
+/**
+ * Make an API request for Cistrome DB Toolkit interval information.
+ * @param {string} assembly
+ * @param {string} chrStartName
+ * @param {number} chrStartPos
+ * @param {string} chrEndName
+ * @param {number} chrEndPos
+ * @returns {Promise} On success, promise resolves with the following array: `[rows, columns]`.
+ */
+export function requestIntervalTFs(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos) {
+    const { 
+        msg: validationMsg, 
+        success: validationSuccess
+    } = validateIntervalParams(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos);
+
+    if(!validationSuccess) {
+        return new Promise((resolve, reject) => {
+            reject(validationMsg);
+        })
+    }
+
+    const dbToolkitAPIURL = makeDBToolkitIntervalAPIURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos);
+
+    return fetch(dbToolkitAPIURL)
+        .then((response) => response.json())
+        .then((data) => {
+            const keys = Object.keys(data);
+
+            return new Promise((resolve, reject) => {
+                if(keys.length === 0) {
+                    reject(`No data found for interval ${chrStartName}:${chrStartPos}-${chrEndPos}`);
+                }
+                // Generate data for table.
+                const rows = keys.map(k => data[k]);
+                const filteredRows = rows.slice(0, rows.length < 100 ? rows.length : 100);
+                const columns = Object.keys(data[keys[0]]);
+                resolve([filteredRows, columns]);
+            });
+        });
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -31,5 +31,3 @@ export const POSITION = Object.freeze({
 export const CONTEXT_MENU_TYPE = Object.freeze({
     NOMINAL_BAR: "context-menu-type-nominal-bar"
 });
-
-export const CISTROME_DBTOOLKIT_MAX_INTERVAL_SIZE = 2000000;


### PR DESCRIPTION
(This is a pull request into your pull request.)

The useEffect and useState after the return statement [here](https://github.com/hms-dbmi/cistrome-higlass-wrapper/compare/sehilyi/fix-137...keller-mark/table-refactoring?expand=1#diff-adae11a6acfedf9f91b7f703a7c80679L58) in TrackWrapper  were throwing this error so I moved them to a separate component to fix it
![Screen Shot 2020-03-05 at 9 35 39 AM](https://user-images.githubusercontent.com/7525285/76003390-fd5d0c00-5ed5-11ea-83e5-cf2a9acbc2e8.png) I think this is because react needs to execute the "hooks" functions in the same order and in the same amount every render due to how it keeps track of the results internally. 

Also these changes should partially address the TODO statement about moving the logic out of the TrackWrapper (though obviously the positioning of the table eventually should be addressed)

This pull request replaces the `XMLHttpRequest` with `fetch` because I think the Promises that fetch uses are a bit easier to deal with than the callback parameters that XMLHttpRequest uses https://github.com/hms-dbmi/cistrome-higlass-wrapper/compare/sehilyi/fix-137...keller-mark/table-refactoring?expand=1#diff-dfc1826173a6c681dbd87cea01e0ab4cR68 If there are other considerations we should be making for the http requests that would favor XMLHttpRequest over fetch then we should also discuss them.

I moved the code for the validation of the interval parameters to a utils file so it can be used both to show/hide the button in TrackColSelectionInfo and to determine whether the URL can be generated by the DataTable wrapper component. It seems better to generate the URL closer to the table component that needs to make the request, rather than closer to the button that triggers the request.

Some of these changes do change the actual behavior of the interface (such as whether the loading spinner appears near the button or whether it appears near the table) so we may want to discuss that or only adopt some of these changes. 

I moved some of the css too. In the future we should discuss different ways to organize the css and whether we want to keep spreading it across separate files or not, but I think it is fine for now.

