### PR TITLE
Compute nominal bar color scale based on original rowInfo array to keep colors after filtering events

### DIFF
--- a/.documentation.yml
+++ b/.documentation.yml
@@ -8,6 +8,7 @@ toc:
 - DataTableForIntervalTFs
 - ContextMenu
 - Tooltip
+- TooltipContent
 - TrackColSelectionInfo
 - TrackColTools
 - TrackRowHighlight
@@ -46,6 +47,9 @@ toc:
 - validateIntervalParams
 - makeDBToolkitIntervalAPIURL
 - requestIntervalTFs
+- componentToHex
+- rgbToHex
+- generateNextUniqueColor
 - name: Classes (internal)
 - Two
 - TwoRectangle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 - Fixed bug which prevented wrapper options for sorting, filtering, highlighting from being used upon initial component render.
 - Added resizer elements to their containers and used `d3-drag` for the mouse events.
+- Compute color scale for the `TrackRowInfoVisNominalBar` categorical value visualization based on the full `rowInfo` rather than `transformedRowInfo` so that the original color mapping is kept after row filtering events.
 
 
 ## 0.1.0 - 02/19/20

--- a/src/TrackRowInfo.js
+++ b/src/TrackRowInfo.js
@@ -10,7 +10,8 @@ import TrackRowInfoVis from "./TrackRowInfoVis.js";
  * @prop {number} trackY The track vertical offset.
  * @prop {number} trackWidth The track width.
  * @prop {number} trackHeight The track height.
- * @prop {array} rowInfo Array of JSON objects, one object for each row.
+ * @prop {object[]} rowInfo Array of JSON objects, one object for each sample, without filtering/sorting based on selected rows.
+ * @prop {object[]} transformedRowInfo The `rowInfo` array after transforming by filtering and sorting according to the selected rows.
  * @prop {array} rowInfoAttributes Array of JSON object, one object for the names and types of each attribute.
  * @prop {string} rowInfoPosition The value of the `rowInfoPosition` option.
  * @prop {object} rowSort The options for sorting rows.
@@ -26,6 +27,7 @@ export default function TrackRowInfo(props) {
     const {
         trackX, trackY,
         trackWidth, trackHeight, 
+        rowInfo,
         transformedRowInfo, 
         rowInfoAttributes,
         rowInfoPosition,
@@ -91,6 +93,7 @@ export default function TrackRowInfo(props) {
                     height={d.height}
                     isLeft={isLeft}
                     fieldInfo={d.fieldInfo}
+                    rowInfo={rowInfo}
                     transformedRowInfo={transformedRowInfo}
                     rowSort={rowSort}
                     rowFilter={rowFilter}

--- a/src/TrackRowInfoVis.js
+++ b/src/TrackRowInfoVis.js
@@ -21,7 +21,8 @@ const fieldTypeToVisComponent = {
  * @prop {number} top The top position of this view.
  * @prop {number} width The width of this view.
  * @prop {number} height The height of this view.
- * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object[]} rowInfo Array of JSON objects, one object for each sample, without filtering/sorting based on selected rows.
+ * @prop {object[]} transformedRowInfo The `rowInfo` array after transforming by filtering and sorting according to the selected rows.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {object} rowSort The options for sorting rows.
@@ -38,6 +39,7 @@ export default function TrackRowInfoVis(props) {
         left, top, width, height,
         fieldInfo,
         isLeft,
+        rowInfo,
         transformedRowInfo,
         rowSort,
         rowFilter,
@@ -160,6 +162,7 @@ export default function TrackRowInfoVis(props) {
                     height,
                     isLeft,
                     fieldInfo,
+                    rowInfo,
                     transformedRowInfo,
                     titleSuffix,
                     onSortRows,

--- a/src/TrackRowInfoVisDendrogram.js
+++ b/src/TrackRowInfoVisDendrogram.js
@@ -15,7 +15,7 @@ import { TooltipContent, destroyTooltip } from './Tooltip.js';
  * @prop {number} top The top position of this view.
  * @prop {number} width The width of this view.
  * @prop {number} height The height of this view.
- * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object[]} transformedRowInfo The `rowInfo` array after transforming by filtering and sorting according to the selected rows.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {function} onSortRows
@@ -25,9 +25,9 @@ import { TooltipContent, destroyTooltip } from './Tooltip.js';
 export default function TrackRowInfoVisDendrogram(props) {
     const {
         left, top, width, height,
+        transformedRowInfo,
         fieldInfo,
         isLeft,
-        transformedRowInfo,
         onSortRows,
         onFilterRows,
         drawRegister,

--- a/src/TrackRowInfoVisLink.js
+++ b/src/TrackRowInfoVisLink.js
@@ -17,7 +17,7 @@ const margin = 5;
  * @prop {number} top The top position of this view.
  * @prop {number} width The width of this view.
  * @prop {number} height The height of this view.
- * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object[]} transformedRowInfo The `rowInfo` array after transforming by filtering and sorting according to the selected rows.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.

--- a/src/TrackRowInfoVisNominalBar.js
+++ b/src/TrackRowInfoVisNominalBar.js
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useState } from "react";
+import React, { useRef, useCallback, useEffect, useState, useMemo } from "react";
 import range from "lodash/range";
 import PubSub from "pubsub-js";
 
@@ -19,7 +19,8 @@ export const margin = 5;
  * @prop {number} top The top position of this view.
  * @prop {number} width The width of this view.
  * @prop {number} height The height of this view.
- * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object[]} rowInfo Array of JSON objects, one object for each sample, without filtering/sorting based on selected rows.
+ * @prop {object[]} transformedRowInfo The `rowInfo` array after transforming by filtering and sorting according to the selected rows.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
@@ -33,6 +34,7 @@ export default function TrackRowInfoVisNominalBar(props) {
         left, top, width, height,
         fieldInfo,
         isLeft,
+        rowInfo,
         transformedRowInfo,
         titleSuffix,
         onSortRows,
@@ -53,9 +55,12 @@ export default function TrackRowInfoVisNominalBar(props) {
         .domain(range(transformedRowInfo.length))
         .range([0, height]);
     const rowHeight = yScale.bandwidth();
-    const colorScale = d3.scaleOrdinal()
-        .domain(Array.from(new Set(transformedRowInfo.map(d => d[field]))).sort()) 
-        .range(d3.schemeTableau10);
+
+    const colorScale = useMemo(() => 
+        d3.scaleOrdinal()
+            .domain(Array.from(new Set(rowInfo.map(d => d[field]))).sort())
+            .range(d3.schemeTableau10),
+    [rowInfo]);
 
     const draw = useCallback((domElement) => {
         const two = new Two({

--- a/src/TrackRowInfoVisQuantitativeBar.js
+++ b/src/TrackRowInfoVisQuantitativeBar.js
@@ -21,7 +21,7 @@ export const margin = 5;
  * @prop {number} top The top position of this view.
  * @prop {number} width The width of this view.
  * @prop {number} height The height of this view.
- * @prop {object[]} transformedRowInfo Array of JSON objects, one object for each row.
+ * @prop {object[]} transformedRowInfo The `rowInfo` array after transforming by filtering and sorting according to the selected rows.
  * @prop {object} fieldInfo The name and type of data field.
  * @prop {boolean} isLeft Is this view on the left side of the track?
  * @prop {string} titleSuffix The suffix of a title, information about sorting and filtering status.
@@ -33,9 +33,9 @@ export const margin = 5;
 export default function TrackRowInfoVisQuantitativeBar(props) {
     const {
         left, top, width, height,
+        transformedRowInfo,
         fieldInfo,
         isLeft,
-        transformedRowInfo,
         titleSuffix,
         onSortRows,
         onSearchRows,

--- a/src/TrackWrapper.js
+++ b/src/TrackWrapper.js
@@ -115,6 +115,7 @@ export default function TrackWrapper(props) {
         <div className="cistrome-hgw-track-wrapper">
             {leftAttrs.length !== 0 ? 
                 (<TrackRowInfo 
+                    rowInfo={rowInfo}
                     transformedRowInfo={transformedRowInfo}
                     viewId={multivecTrackViewId}
                     trackId={multivecTrackTrackId}
@@ -134,6 +135,7 @@ export default function TrackWrapper(props) {
                 />) : null}
             {rightAttrs.length !== 0 ? 
                 (<TrackRowInfo
+                    rowInfo={rowInfo}
                     transformedRowInfo={transformedRowInfo}
                     viewId={multivecTrackViewId}
                     trackId={multivecTrackTrackId}


### PR DESCRIPTION
Fixes #160 