### PR TITLE
Data table checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added a context menu for filtering or highlighting rows based on a nomival value in categorical bar charts.
 - Added hover styles for the `TrackRowInfoVisLink` visualization component, so that when a link area is hovered, a gray background rect and a text underline are also rendered.
 - Added a context menu to add a new track on top or bottom with selected rows in categorical bar charts.
+- Added an option to render a checkbox for each row of the data table, with a callback function that takes an array of checked row objects.
 
 ### Changed
 - Fixed bug which prevented wrapper options for sorting, filtering, highlighting from being used upon initial component render.


### PR DESCRIPTION
This pull request adds the `onCheckRows` option for the DataTable component. If the function is provided as a prop, then the checkboxes will be rendered (but otherwise no checkboxes will be rendered).

Fixes #184 