### PR TITLE
Properly position titles of wrapper tracks in SVG

### DIFF
--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -29,7 +29,7 @@ export function generateNextUniqueColor(i) {
         // https://stackoverflow.com/questions/15804149/rgb-color-permutation/15804183#15804183
         return rgbToHex([i & 0xff, (i & 0xff00) >> 8, (i & 0xff0000) >> 16]);
     } else {
-        console.log("WARNING: unique colors out of range.");
+        console.warn("Unique colors are out of range generateNextUniqueColor().");
         return "#000000";
     }
 }

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -195,7 +195,7 @@ export function processWrapperOptions(optionsRaw) {
     // Validate the raw options:
     const valid = validateWrapperOptions(optionsRaw);
     if(!valid) {
-        console.log("WARNING: Invalid Wrapper Options.");
+        console.warn("Invalid Wrapper Options in processWrapperOptions().");
         return options;
     }
 

--- a/src/utils/two.js
+++ b/src/utils/two.js
@@ -564,6 +564,11 @@ export default class Two {
             dims.width = width;
             dims.height = height;
         } catch(e) {
+            console.warn(e);
+        }
+
+        // Approximate text dimensions when not assigned properly.
+        if(dims.width === 0 && dims.height === 0){
             console.warn("Approximating text dimensions in Two.measureTextSvg().");
             dims.width = content.length;
             dims.height = d.fontsize;

--- a/src/utils/viewconf.js
+++ b/src/utils/viewconf.js
@@ -116,7 +116,7 @@ export function addTrackDefToViewConfig(currViewConfig, trackDef, targetViewId, 
     if(viewIndex !== -1) {
         newViewConfig.views[viewIndex].tracks[position].push(trackDef);
     } else {
-        console.log(`WARNING: The following track is not found (${targetViewId}, ${neighborTrackId}).`);
+        console.warn(`The following track is not found (${targetViewId}, ${neighborTrackId}) in addTrackDefToViewConfig().`);
     }
     return newViewConfig;
 }


### PR DESCRIPTION
This pull request fixes the first bug illustrated in #201. The bug was based on the `measureTextSvg()` where the `text.node().getBBox()` line does not catch errors but also not assign proper text dimensions, (`width` and `height` === 0). This caused titles to be improperly positioned only in Chrome in my local settings.

