### PR TITLE
Merge cistrome toolkit api responses into single table

### DIFF
--- a/src/DataTableForIntervalTFs.js
+++ b/src/DataTableForIntervalTFs.js
@@ -1,8 +1,61 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 
 import DataTable from "./DataTable.js";
 
 import { requestIntervalTFs } from './utils/cistrome.js';
+
+/**
+ * Merge all api responses into a single set of rows and columns.
+ * @param {object[]} allApiResponses Array of api response objects, containing the properties `success`, `rows`, `columns`.
+ * @returns {array} The result is an array `[rows, columns]` containing the merged values.
+ */
+function mergeReponses(allApiResponses) {
+    // Only use the successful responses.
+    const apiResponses = allApiResponses.filter(d => d.success);
+    let rows = [];
+    let columns = [];
+    const minNumRows = Math.min(...apiResponses.map(d => d.rows.length));
+    // Use all possible column values.
+    for(let apiResponse of apiResponses) {
+        columns = [ ...apiResponse.columns, ...columns ];
+    }
+    // For each row, compute the product of OverlapRatios across responses.
+    for(let i = 0; i < minNumRows; i++) {
+        let rankProduct = 1;
+        for(let apiResponse of apiResponses) {
+            rankProduct *= apiResponse.rows[i]['OverlapRatio'];
+        }
+        for(let apiResponse of apiResponses) {
+            const row = apiResponse.rows[i];
+            row['OverlapRatioRankProduct'] = rankProduct;
+            row['Rank'] = i;
+            // Append this row to the output row array.
+            rows.push(row);
+        }
+    }
+    // Sort all rows by the rank product value rather than the overlap ratio value.
+    rows.sort((a, b) => {
+        return b['OverlapRatioRankProduct'] - a['OverlapRatioRankProduct'];
+    })
+    columns.push('OverlapRatioRankProduct');
+    columns.push('Rank');
+    // Return the processed rows array, and all unique column names.
+    return [rows, Array.from(new Set(columns))];
+}
+
+/**
+ * Generate a name from an object of interval parameters.
+ * @param {object} intervalParams The interval parameters.
+ * @returns {string} A name for the parameters object.
+ */
+function getIntervalName(intervalParams) {
+    const {
+        chrStartName, 
+        chrStartPos, 
+        chrEndPos
+    } = intervalParams;
+    return `${chrStartName}:${chrStartPos}-${chrEndPos}`;
+}
 
 /**
  * Wrapper around <DataTable />, specific for showing the TF binding interval request results.
@@ -20,43 +73,70 @@ import { requestIntervalTFs } from './utils/cistrome.js';
 export default function DataTableForIntervalTFs(props) {
     const {
         left, top, width, height,
-        intervalParams
+        allIntervalParams
     } = props;
-
-    const {
-        assembly, 
-        chrStartName, 
-        chrStartPos, 
-        chrEndName, 
-        chrEndPos
-    } = intervalParams;
 
     const [isVisible, setIsVisible] = useState(false);
     const [requestStatus, setRequestStatus] = useState(null);
     const [dataTableRows, setDataTableRows] = useState([]);
     const [dataTableColumns, setDataTableColumns] = useState([]);
 
+    // Store both parameters and the response results, before merging.
+    const apiResponses = useRef();
+
     useEffect(() => {
         let didUnmount = false;
-        setRequestStatus({ msg: "Receiving Cistrome DB API response...", isLoading: true });
-        if(intervalParams) {
-            requestIntervalTFs(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos)
-                .then(([rows, columns]) => {
-                    if(didUnmount) return;
-                    setDataTableRows(rows);
-                    setDataTableColumns(columns);
+        if(allIntervalParams.length > 0) {
+            setDataTableColumns([]);
+            setDataTableRows([]);
+            setRequestStatus({ msg: `Loading Cistrome DB Toolkit API response for ${allIntervalParams.length} intervals...`, isLoading: true });
+            for(let intervalParams of allIntervalParams) {
+                const {
+                    assembly, 
+                    chrStartName, 
+                    chrStartPos, 
+                    chrEndName, 
+                    chrEndPos
+                } = intervalParams;
 
-                    const msg = `For interval ${chrStartName}:${chrStartPos}-${chrEndPos}`;
-                    setRequestStatus({ msg, isLoading: false });
-                })
-                .catch((msg) => {
-                    if(didUnmount) return;
-                    setRequestStatus({ msg, isLoading: false });
-                })
+                const intervalName = getIntervalName(intervalParams);
+    
+                apiResponses.current = {};
+                requestIntervalTFs(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos)
+                    .then(([rows, columns]) => {
+                        if(didUnmount) return;
+
+                        rows.sort((a, b) => {
+                            return b['OverlapRatio'] - a['OverlapRatio'];
+                        });
+
+                        apiResponses.current[intervalName] = {
+                            rows, columns, success: true
+                        };
+
+                        // Merge the rows from all api responses if all responses have finished (either successfully or unsuccessfully).
+                        if(Object.keys(apiResponses.current).length === allIntervalParams.length) {
+                            const [allRows, allColumns] = mergeReponses(Object.values(apiResponses.current));
+                            setDataTableColumns(allColumns);
+                            setDataTableRows(allRows);
+                            
+                            const allIntervalNames = Object.keys(apiResponses.current).map(k => (apiResponses.current[k].success ? k : `${k} (failed)`)).join(', ');
+                            const msg = `For interval${allIntervalParams.length === 1 ? '' : 's'} ${allIntervalNames}`;
+                            setRequestStatus({ msg, isLoading: false });
+                        }
+                    })
+                    .catch((msg) => {
+                        if(didUnmount) return;
+                        apiResponses.current[intervalName] = {
+                            success: false
+                        };
+                        setRequestStatus({ msg, isLoading: false });
+                    });
+            }
+            setIsVisible(true);
         }
-        setIsVisible(true);
         return (() => { didUnmount = true; });
-    }, [intervalParams]);
+    }, [allIntervalParams]);
 
     return (requestStatus && isVisible ? (
         <DataTable 

--- a/src/ViewWrapper.js
+++ b/src/ViewWrapper.js
@@ -37,7 +37,7 @@ export default function ViewWrapper(props) {
     const [chrName, setChrName] = useState("");
     const [chrPos, setChrPos] = useState("");
     
-    const [requestedIntervalParams, setRequestedIntervalParams] = useState(null);
+    const [allIntervalParams, setAllIntervalParams] = useState([]);
 
     const brushBarHeight = 24;
 
@@ -182,7 +182,7 @@ export default function ViewWrapper(props) {
                                     multivecTrack={multivecTrack}
                                     onViewportRemove={onViewportRemove}
                                     onRequestIntervalTFs={(intervalParams) => {
-                                        setRequestedIntervalParams(intervalParams);
+                                        setAllIntervalParams([ intervalParams, ...allIntervalParams ]);
                                     }}
                                 />
                             ) : null;
@@ -237,13 +237,13 @@ export default function ViewWrapper(props) {
                     width: `${width}px`
                 }}
             >
-                {requestedIntervalParams ? 
+                {allIntervalParams.length > 0 ? 
                     <DataTableForIntervalTFs
                         left={0}
                         top={0}
                         width={width}
                         height={600}
-                        intervalParams={requestedIntervalParams}
+                        allIntervalParams={allIntervalParams}
                     />
                 : null}
             </div>

--- a/src/utils/cistrome.js
+++ b/src/utils/cistrome.js
@@ -65,7 +65,7 @@ export function requestIntervalTFs(assembly, chrStartName, chrStartPos, chrEndNa
 
     const dbToolkitAPIURL = makeDBToolkitIntervalAPIURL(assembly, chrStartName, chrStartPos, chrEndName, chrEndPos);
 
-    return fetch(dbToolkitAPIURL)
+    return fetch(dbToolkitAPIURL, { cache: "force-cache" })
         .then((response) => {
             if (!response.ok) {
                 return new Promise((resolve, reject) => {


### PR DESCRIPTION
This pull request contains code to merge multiple cistrome genomic interval API responses into a single array of rows to pass to the DataTable.

It is still a bit confusing because the merged table uses all of the `intervalParams` arrays generated when the search icons are clicked.

If you close the table, it does not clear out the `intervalParams`, so the next time you click a search button, the new set of intervalParams just gets added to the existing array.

I think we should add an issue to link the interval parameters to the viewport-projection-horizontal brushing windows, and maybe also remove the search icon and enable the table to be automatically linked to the current genomic interval selections. This way if you change or remove an interval, the table will automatically update to reflect the selected intervals.

Fixes #181