### PR TITLE
Remove view.layout.moved/static in demo viewConfigs

### DIFF
--- a/src/viewconfigs/horizontal-multivec-1.json
+++ b/src/viewconfigs/horizontal-multivec-1.json
@@ -135,9 +135,7 @@
           "w": 12,
           "h": 10,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-1"
       }

--- a/src/viewconfigs/horizontal-multivec-2.json
+++ b/src/viewconfigs/horizontal-multivec-2.json
@@ -139,9 +139,7 @@
           "w": 12,
           "h": 71,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-2"
       }

--- a/src/viewconfigs/horizontal-multivec-3.json
+++ b/src/viewconfigs/horizontal-multivec-3.json
@@ -183,9 +183,7 @@
           "w": 12,
           "h": 71,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-1"
       }

--- a/src/viewconfigs/horizontal-multivec-4.json
+++ b/src/viewconfigs/horizontal-multivec-4.json
@@ -308,9 +308,7 @@
           "w": 6,
           "h": 71,
           "x": 6,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-4-2"
       }

--- a/src/viewconfigs/horizontal-multivec-5.json
+++ b/src/viewconfigs/horizontal-multivec-5.json
@@ -140,9 +140,7 @@
           "w": 12,
           "h": 71,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-5"
       }

--- a/src/viewconfigs/horizontal-multivec-6.json
+++ b/src/viewconfigs/horizontal-multivec-6.json
@@ -139,9 +139,7 @@
           "w": 6,
           "h": 90,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-6-1"
       },

--- a/src/viewconfigs/horizontal-multivec-7.json
+++ b/src/viewconfigs/horizontal-multivec-7.json
@@ -133,9 +133,7 @@
           "w": 12,
           "h": 10,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-7"
       }

--- a/src/viewconfigs/horizontal-multivec-8.json
+++ b/src/viewconfigs/horizontal-multivec-8.json
@@ -134,9 +134,7 @@
           "w": 12,
           "h": 10,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-8"
       }

--- a/src/viewconfigs/horizontal-multivec-9.json
+++ b/src/viewconfigs/horizontal-multivec-9.json
@@ -203,9 +203,7 @@
           "w": 12,
           "h": 77,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "cistrome-view-1"
       }

--- a/src/viewconfigs/meeting-2020-04-29.json
+++ b/src/viewconfigs/meeting-2020-04-29.json
@@ -135,9 +135,7 @@
           "w": 12,
           "h": 10,
           "x": 0,
-          "y": 0,
-          "moved": false,
-          "static": false
+          "y": 0
         },
         "uid": "meeting-2020-04-29-view"
       }


### PR DESCRIPTION
Removed two options, `view.layout.moved` and `view.layout.static`, in all the demo view configs since they are not allowed according to the definition of json schema in HiGlass and were making warning messages in console.

React-grid-layout autogenerates these options when rendering HiGlass (https://github.com/higlass/higlass/pull/700), and we perhaps took these options by copy and pasting the entire viewConfigs shown on the interface of HiGlass settings.

Before:
<img width="457" alt="Screen Shot 2020-05-07 at 12 47 01 PM" src="https://user-images.githubusercontent.com/9922882/81322555-2b8bd300-9062-11ea-8f50-7ea5f775409d.png">
